### PR TITLE
fix: response schema and enum values

### DIFF
--- a/src/main/java/com/example/repick/domain/product/api/ProductController.java
+++ b/src/main/java/com/example/repick/domain/product/api/ProductController.java
@@ -198,23 +198,23 @@ public class ProductController {
         return SuccessResponse.createSuccess(paymentService.validatePayment(postPayment));
     }
 
-    @Operation(summary = "상품 타입 조회",
+    @Operation(summary = "상품 타입 조회: 스타일",
             description = """
-                    # 상품 타입을 조회합니다.
-                    
-                    ### 조회 가능 타입
-                    
-                    - 여성 카테고리
-                    - 남성 카테고리
-                    - 스타일
-                    
+                    - 상품 스타일 타입을 조회합니다.
                     """)
-    @GetMapping("/classifications")
-    public SuccessResponse<List<GetType>> getProductTypes(
-            @Parameter(description = "타입 종류 (카테고리, 스타일)") @RequestParam String type,
-            @Parameter(description = "성별 (남성 또는 여성)") @RequestParam(required = false) String gender
-    ) {
-        return SuccessResponse.success(productService.getProductTypes(type, gender));
+    @GetMapping("/classification/styles")
+    public SuccessResponse<List<GetClassificationEach>> getProductTypes() {
+        return SuccessResponse.success(productService.getProductStyleTypes());
+    }
+
+    @Operation(summary = "상품 타입 조회: 카테고리",
+            description = """
+                    - 상품 카테고리 타입을 조회합니다.
+                    """)
+    @GetMapping("/classification/categories")
+    public SuccessResponse<GetClassification> getProductTypes(
+            @Parameter(description = "성별 (남성 또는 여성)") @RequestParam(required = false) String gender) {
+        return SuccessResponse.success(productService.getProductCategoryTypes(gender));
     }
 
     @Operation(summary = "상품 상세 조회",

--- a/src/main/java/com/example/repick/domain/product/dto/GetClassification.java
+++ b/src/main/java/com/example/repick/domain/product/dto/GetClassification.java
@@ -1,0 +1,17 @@
+package com.example.repick.domain.product.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record GetClassification(
+        @Schema(description = "아우터") List<GetClassificationEach> outer,
+        @Schema(description = "상의") List<GetClassificationEach> top,
+        @Schema(description = "하의") List<GetClassificationEach> bottom,
+        @Schema(description = "스커트") List<GetClassificationEach> skirt,
+        @Schema(description = "원피스") List<GetClassificationEach> onePiece
+) {
+    public static GetClassification of(List<GetClassificationEach> outer, List<GetClassificationEach> top, List<GetClassificationEach> bottom, List<GetClassificationEach> skirt, List<GetClassificationEach> onePiece) {
+        return new GetClassification(outer, top, bottom, skirt, onePiece);
+    }
+}

--- a/src/main/java/com/example/repick/domain/product/dto/GetClassificationEach.java
+++ b/src/main/java/com/example/repick/domain/product/dto/GetClassificationEach.java
@@ -4,16 +4,16 @@ import com.example.repick.domain.product.entity.Category;
 import com.example.repick.domain.product.entity.Style;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record GetType(
+public record GetClassificationEach(
         @Schema(description = "타입 ID", example = "1") int id,
         @Schema(description = "타입명", example = "상의") String type,
         @Schema(description = "타입 코드", example = "TOP") String code
 ) {
-    public static GetType of(Style style) {
-        return new GetType(style.getId(), style.getValue(), style.name());
+    public static GetClassificationEach of(Style style) {
+        return new GetClassificationEach(style.getId(), style.getValue(), style.name());
     }
 
-    public static GetType of(Category category) {
-        return new GetType(category.getId(), category.getValue(), category.name().substring(0, 3));
+    public static GetClassificationEach of(Category category) {
+        return new GetClassificationEach(category.getId(), category.getValue(), category.name());
     }
 }

--- a/src/main/java/com/example/repick/domain/product/entity/Category.java
+++ b/src/main/java/com/example/repick/domain/product/entity/Category.java
@@ -2,46 +2,38 @@ package com.example.repick.domain.product.entity;
 
 import com.example.repick.global.error.exception.CustomException;
 import com.example.repick.global.error.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter @AllArgsConstructor
 public enum Category {
 
-    TEST(1, "테스트"),
+    TEST(1, "테스트", "테스트", "테스트"),
 
     // 아우터
-    CAR8(2, "가디건"), BLA8(3, "자켓"), WIN8(4, "바람막이"),
-    COA8(5, "코트"), PAD8(6, "패딩"), FLE8(7, "후리스"),
-    JIP8(8, "집업/점퍼"), MIL8(9, "야상"),
+    CAR(2, "가디건", "아우터", "공용"), BLA(3, "자켓", "아우터", "공용"), WIN(4, "바람막이", "아우터", "공용"),
+    COA(5, "코트", "아우터", "공용"), PAD(6, "패딩", "아우터", "공용"), FLE(7, "후리스", "아우터", "공용"),
+    JIP(8, "집업/점퍼", "아우터", "공용"), MIL(9, "야상", "아우터", "공용"),
 
     // 상의
-    NON8(10, "민소매"), HAL8(11, "반소매"), LON8(12, "긴소매"),
-    MAN8(13, "맨투맨"), HOO8(14, "후드"), NEA8(15, "니트"),
-    SHI8(16, "셔츠"), VES8(17, "조끼"), BLO6(18, "블라우스"),
+    NON8(10, "민소매", "상의", "공용"), HAL8(11, "반소매", "상의", "공용"), LON8(12, "긴소매", "상의", "공용"),
+    MAN(13, "맨투맨", "상의", "공용"), HOO(14, "후드", "상의", "공용"), NEA(15, "니트", "상의", "공용"),
+    SHI(16, "셔츠", "상의", "공용"), VES(17, "조끼", "상의", "공용"), BLO(18, "블라우스", "상의", "여성"),
 
     // 하의
-    HAP8(19, "반바지"), LOP8(20, "긴바지"), SLA8(21, "슬랙스"),
-    DEN8(22, "데님"), LEG8(23, "레깅스"), JUM8(24, "점프수트"),
+    HAP(19, "반바지", "하의", "공용"), LOP(20, "긴바지", "하의", "공용"), SLA(21, "슬랙스", "하의", "공용"),
+    DEN(22, "데님", "하의", "공용"), LEG(23, "레깅스", "하의", "공용"), JUM(24, "점프수트", "하의", "공용"),
 
     // 스커트
-    MNS6(25, "미니스커트"), MDS6(26, "미디스커트"), LOS6(27, "롱스커트"),
+    MNS(25, "미니스커트", "스커트", "여성"), MDS(26, "미디스커트", "스커트", "여성"), LOS(27, "롱스커트", "스커트", "여성"),
 
     // 원피스
-    MNO6(28, "미니원피스"), LNO6(29, "롱원피스");
+    MNO(28, "미니원피스", "원피스", "여성"), LNO(29, "롱원피스", "원피스", "여성");
 
     private final int id;
     private final String value;
-
-    Category(int id, String value) {
-        this.id = id;
-        this.value = value;
-    }
-
-    public int getId() {
-        return id;
-    }
-
-    public String getValue() {
-        return value;
-    }
+    private final String parent;
+    private final String gender;
 
     public static Category fromId(int id) {
         for (Category category : values()) {

--- a/src/main/java/com/example/repick/domain/product/service/ProductService.java
+++ b/src/main/java/com/example/repick/domain/product/service/ProductService.java
@@ -255,32 +255,37 @@ public class ProductService {
                 .orElseThrow(() -> new CustomException(INVALID_PRODUCT_ID));
     }
 
-    public List<GetType> getProductTypes(String type, String gender) {
-        List<GetType> types = new ArrayList<>();
+    public List<GetClassificationEach> getProductStyleTypes() {
+        List<GetClassificationEach> types = new ArrayList<>();
 
-        if (type.equals("스타일")) {
-            for (Style style : Style.values()) {
-                types.add(GetType.of(style));
-            }
-        }
-
-        else if(type.equals("카테고리")) {
-            if (gender.equals("남성")) {
-                for (Category category : Category.values()) {
-                    if (category.name().charAt(3) == '7' || category.name().charAt(3) == '8') {
-                        types.add(GetType.of(category));
-                    }
-                }
-            } else if (gender.equals("여성")) {
-                for (Category category : Category.values()) {
-                    if (category.name().charAt(3) == '6' || category.name().charAt(3) == '8') {
-                        types.add(GetType.of(category));
-                    }
-                }
-            }
+        for (Style style : Style.values()) {
+            types.add(GetClassificationEach.of(style));
         }
 
         return types;
+    }
+
+    public GetClassification getProductCategoryTypes(String gender) {
+        List<GetClassificationEach> outer = new ArrayList<>();
+        List<GetClassificationEach> top = new ArrayList<>();
+        List<GetClassificationEach> bottom = new ArrayList<>();
+        List<GetClassificationEach> skirt = new ArrayList<>();
+        List<GetClassificationEach> onePiece = new ArrayList<>();
+
+        for (Category category : Category.values()) {
+            if (category.getGender().equals(gender) || category.getGender().equals("공용")) {
+                switch (category.getParent()) {
+                    case "아우터" -> outer.add(GetClassificationEach.of(category));
+                    case "상의" -> top.add(GetClassificationEach.of(category));
+                    case "하의" -> bottom.add(GetClassificationEach.of(category));
+                    case "스커트" -> skirt.add(GetClassificationEach.of(category));
+                    case "원피스" -> onePiece.add(GetClassificationEach.of(category));
+                }
+            }
+        }
+
+
+        return new GetClassification(outer, top, bottom, skirt, onePiece);
     }
 
     public GetProductDetail getProductDetail(Long productId) {


### PR DESCRIPTION
#57 카테고리 리스트 응답 스키마 변경

### 1. API 분리

<img width="646" alt="image" src="https://github.com/Repick-official/repick-server-v2/assets/76674422/12cdfb18-dc95-487d-9ae4-2dfbca0e0190">

스타일 리스트 조회 API와 카테고리 리스트 조회 API를 분리합니다.

<img width="1241" alt="image" src="https://github.com/Repick-official/repick-server-v2/assets/76674422/696b0792-af8b-40aa-b8d1-2cb363314a86">

응답 스키마는 다음과 같이 수정합니다.

Category ENUM에 두 가지 밸류를 추가합니다:

- parent: 상위 카테고리를 나타냄
- gender: 성별을 나타냄

