### PR TITLE
fix: apple login

### DIFF
--- a/src/main/java/com/example/repick/domain/user/api/UserController.java
+++ b/src/main/java/com/example/repick/domain/user/api/UserController.java
@@ -108,7 +108,7 @@ public class UserController {
                     개발용 유저 삭제 API를 통해 최초 회원가입이 정상적으로 처리되는지 확인할 수 있습니다.
                   
                     요청값:
-                    - (Query Parameter) code: 애플 인증서버에서 받은 인증 코드
+                    - (Query Parameter) id_token: 애플 인증서버에서 받은 id_token
                     
                     반환값:
                     - accessToken: 서버 내부에서 발급한 토큰입니다.
@@ -117,7 +117,6 @@ public class UserController {
     @PostMapping("/oauth/apple")
     public SuccessResponse<TokenResponse> callback(@Parameter(name = "id_token", description = "애플 인증서버에서 받은 id_token", required = true)
                                                    @RequestParam String id_token) {
-        System.out.println("id_token = " + id_token);
 
         Pair<TokenResponse, Boolean> pair = appleUserService.appleLogin(id_token);
 

--- a/src/main/java/com/example/repick/domain/user/entity/OAuthProvider.java
+++ b/src/main/java/com/example/repick/domain/user/entity/OAuthProvider.java
@@ -1,5 +1,7 @@
 package com.example.repick.domain.user.entity;
 
 public enum OAuthProvider {
-    KAKAO,NAVER
+    KAKAO,
+    NAVER,
+    APPLE
 }

--- a/src/main/java/com/example/repick/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/repick/domain/user/repository/UserRepository.java
@@ -7,6 +7,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findByProviderId(String email);
+    Optional<User> findByProviderId(String providerId);
 
 }

--- a/src/main/java/com/example/repick/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/example/repick/global/error/exception/ErrorCode.java
@@ -66,7 +66,7 @@ public enum ErrorCode {
     USER_SMS_VERIFICATION_NOT_FOUND(404, "A001", "인증번호가 만료되었거나 존재하지 않습니다."),
     USER_SMS_VERIFICATION_EXPIRED(400, "A002", "인증번호가 만료되었습니다."),
     // Apple OAuth
-    APPLE_LOGIN_FAILED(400, "A011", "인증 코드가 올바르지 않거나 만료되었습니다."),
+    APPLE_LOGIN_FAILED(400, "A011", "유효하지 않은 id 토큰입니다"),
     //FCM
     USER_FCM_TOKEN_NOT_FOUND(404, "A021", "존재하지 않는 FCM 토큰입니다."),
     // Advertisement

--- a/src/main/java/com/example/repick/global/oauth/AppleUserService.java
+++ b/src/main/java/com/example/repick/global/oauth/AppleUserService.java
@@ -111,7 +111,6 @@ public class AppleUserService {
                     .pushAllow(false)
                     .build();
             userRepository.save(newUser);
-            System.out.println("providerId = " + newUser.getProviderId());
             return Pair.of(newUser, true);
         }
     }


### PR DESCRIPTION
# fix: apple login
**Apple login 완성**

1. 클라이언트에서 애플 서버에 요청해 받은 **id token** 으로 리픽 서버에 요청 (response type에 id_token 있어야 함)

   애플 서버 요청 예시: 
   ```
   https://appleid.apple.com/auth/authorize?client_id=[CLIENT_ID]&redirect_uri=[REDIRECT_URI]&response_type=code%20id_token&scope=name%20email&response_mode=form_post
   ```
3. 토큰 검증 및 사용자 정보(이메일) 추출
4. 가입하지 않은 사용자라면 회원가입
5. access, refresh token response
    **애플 서버에서 제공하는 토큰이 아니라 리픽 서버에서 발급하는 토큰이다**