### PR TITLE
fix: delete userSmsVerificationInfo error

### DIFF
--- a/src/main/java/com/example/repick/domain/user/service/UserService.java
+++ b/src/main/java/com/example/repick/domain/user/service/UserService.java
@@ -91,6 +91,7 @@ public class UserService {
         return true;
     }
 
+    @Transactional
     public Boolean initSmsVerification(PostInitSmsVerification postInitSmsVerification) {
         User user = userRepository.findByProviderId(SecurityContextHolder.getContext().getAuthentication().getName())
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
@@ -110,6 +111,7 @@ public class UserService {
         return true;
     }
 
+    @Transactional
     public Boolean verifySmsVerification(PostVerifySmsVerification postVerifySmsVerification) {
         User user = userRepository.findByProviderId(SecurityContextHolder.getContext().getAuthentication().getName())
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
@@ -127,7 +129,7 @@ public class UserService {
 
         userRepository.save(user);
 
-        userSmsVerificationInfoRepository.deleteById(userSmsVerificationInfo.getId());
+        userSmsVerificationInfoRepository.deleteAllByUserId(user.getId());
 
         return true;
     }

--- a/src/main/java/com/example/repick/dynamodb/UserSmsVerificationInfoRepository.java
+++ b/src/main/java/com/example/repick/dynamodb/UserSmsVerificationInfoRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 @EnableScan
 public interface UserSmsVerificationInfoRepository extends CrudRepository<UserSmsVerificationInfo, String> {
     Optional<UserSmsVerificationInfo> findByUserIdAndPhoneNumberAndVerificationCode(Long userId, String phoneNumber, String verificationCode);
+    void deleteAllByUserId(Long userId);
 }


### PR DESCRIPTION
# #67 문자 인증시 오류 수정

문자 인증 시 500 에러가 발생하는 에러를 발견하였고 이를 수정합니다.
---

## 수정 내용

### 1. 문자 인증 완료 시 데이터 삭제 로직 변경

``` Java
// 기존
userSmsVerificationInfoRepository.deleteById();
```

인증할 때 쓰였던 문자 인증 데이터만 삭제합니다.

해당 로직이 DDB의 데이터 저장 자료형과 충돌하여 500 에러를 발생시켰습니다.

수정
``` Java
// 수정
userSmsVerificationInfoRepository.deleteAllByUserId(user.getId());
```

유저 id 기준으로 모든 데이터를 삭제합니다.

### 2. Transactional

Transactional 어노테이션을 추가했습니다.

