### PR TITLE
Bug/cicd image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Push to ECR
 
 on:
   push:
-    branches: [ "bug/cicd-image" ]
+    branches: [ "develop" ]
 
 env:
   AWS_REGION: ap-northeast-2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,13 +2,12 @@ name: Push to ECR
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: [ "bug/cicd-image" ]
 
 env:
   AWS_REGION: ap-northeast-2
   ECR_REGISTRY: 654654448479.dkr.ecr.ap-northeast-2.amazonaws.com
   ECR_REPOSITORY: repick-repo
-  IMAGE_TAG: ${{ github.sha }}
 
 permissions:
   contents: read
@@ -61,8 +60,8 @@ jobs:
       - name: Build, tag, and push image to Amazon ECR
         id: build-image
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY
 
   deploy:
     needs: build
@@ -95,7 +94,7 @@ jobs:
             aws configure set region ${{ env.AWS_REGION }}
             ECR_REGISTRY_LOGIN=$(aws ecr get-login-password --region ${{ env.AWS_REGION }} | sudo docker login --username AWS --password-stdin ${{ env.ECR_REGISTRY }})
             sudo docker rm -f $(docker ps -qa)
-            sudo docker pull ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
-            sudo docker run -d --name dc -p 8080:8080 ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
+            sudo docker pull ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}
+            sudo docker run -d --name dc -p 8080:8080 ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}
             sudo docker image prune -f
 


### PR DESCRIPTION
# #77 도커 이미지로 인한 EBS 관련 문제

이미지 태깅을 제거하여 latest 태그로 이미지를 받아오도록 구성합니다.

![image](https://github.com/Repick-official/repick-server-v2/assets/76674422/acc8d5f1-5d35-4fbd-a562-5b1035ab9edd)

기존에 해시를 이용하여 태깅을 하는 방식으로 ECR에 들어가는 이미지가 너무 많아지는 문제를 발견했고 이를 수정합니다.
(기존 이미지는 모두 삭제했습니다.)

기대 효과
1. ECR 스토리지 최적화로 비용 절감
2. EBS 볼륨 문제로 인한 서버 다운 현상 방지

Production 환경에서는 안정성을 위해 해시 태깅 방식을 다시 도입해야 할 수도 있습니다.