### PR TITLE
Fix: payment concurrency issue

### DIFF
--- a/src/main/java/com/example/repick/domain/clothingSales/service/ClothingSalesService.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/service/ClothingSalesService.java
@@ -167,7 +167,7 @@ public class ClothingSalesService {
             // 상태가 SELLING인 경우 sellingQuantity를 증가시킨다.
             // 상태가 SOLD_OUT인 경우, 해당 state의 createdDate가 7일 이후면 soldQuantity를 증가시키고, 7일 이전이면 pendingQuantity를 증가시킨다.
             productList.forEach(product -> {
-                ProductState productState = productStateRepository.findFirstByProductIdOrderByIdDesc(product.getId()).orElseThrow(() -> new CustomException(INVALID_PRODUCT_ID));
+                ProductState productState = productStateRepository.findFirstByProductIdOrderByCreatedDateDesc(product.getId()).orElseThrow(() -> new CustomException(INVALID_PRODUCT_ID));
                 if (productState.getProductStateType().equals(ProductStateType.SELLING)) {
                     sellingQuantity.getAndSet(sellingQuantity.get() + 1);
                 } else if (productState.getProductStateType().equals(ProductStateType.SOLD_OUT)) {
@@ -196,7 +196,7 @@ public class ClothingSalesService {
             AtomicReference<Integer> soldQuantity = new AtomicReference<>(0);
 
             productList.forEach(product -> {
-                ProductState productState = productStateRepository.findFirstByProductIdOrderByIdDesc(product.getId()).orElseThrow(() -> new CustomException(INVALID_PRODUCT_ID));
+                ProductState productState = productStateRepository.findFirstByProductIdOrderByCreatedDateDesc(product.getId()).orElseThrow(() -> new CustomException(INVALID_PRODUCT_ID));
                 if (productState.getProductStateType().equals(ProductStateType.SELLING)) {
                     sellingQuantity.getAndSet(sellingQuantity.get() + 1);
                 } else if (productState.getProductStateType().equals(ProductStateType.SOLD_OUT)) {

--- a/src/main/java/com/example/repick/domain/clothingSales/service/ClothingSalesService.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/service/ClothingSalesService.java
@@ -7,6 +7,7 @@ import com.example.repick.domain.product.dto.product.PostProductSellingState;
 import com.example.repick.domain.product.entity.Product;
 import com.example.repick.domain.product.entity.ProductState;
 import com.example.repick.domain.product.entity.ProductStateType;
+import com.example.repick.domain.product.repository.ProductStateRepository;
 import com.example.repick.domain.product.service.ProductService;
 import com.example.repick.domain.user.entity.User;
 import com.example.repick.domain.user.repository.UserRepository;
@@ -22,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.example.repick.global.error.exception.ErrorCode.INVALID_PRODUCT_ID;
 import static com.example.repick.global.error.exception.ErrorCode.USER_NOT_FOUND;
 
 @Service @RequiredArgsConstructor
@@ -32,6 +34,7 @@ public class ClothingSalesService {
     private final BoxService boxService;
     private final ProductService productService;
     private final ClothingSalesValidator clothingSalesValidator;
+    private final ProductStateRepository productStateRepository;
 
     public List<GetPendingClothingSales> getPendingClothingSales() {
         User user = userRepository.findByProviderId(SecurityContextHolder.getContext().getAuthentication().getName())
@@ -164,7 +167,7 @@ public class ClothingSalesService {
             // 상태가 SELLING인 경우 sellingQuantity를 증가시킨다.
             // 상태가 SOLD_OUT인 경우, 해당 state의 createdDate가 7일 이후면 soldQuantity를 증가시키고, 7일 이전이면 pendingQuantity를 증가시킨다.
             productList.forEach(product -> {
-                ProductState productState = productService.getProductSellingState(product.getId());
+                ProductState productState = productStateRepository.findFirstByProductIdOrderByIdDesc(product.getId()).orElseThrow(() -> new CustomException(INVALID_PRODUCT_ID);
                 if (productState.getProductStateType().equals(ProductStateType.SELLING)) {
                     sellingQuantity.getAndSet(sellingQuantity.get() + 1);
                 } else if (productState.getProductStateType().equals(ProductStateType.SOLD_OUT)) {
@@ -193,7 +196,7 @@ public class ClothingSalesService {
             AtomicReference<Integer> soldQuantity = new AtomicReference<>(0);
 
             productList.forEach(product -> {
-                ProductState productState = productService.getProductSellingState(product.getId());
+                ProductState productState = productStateRepository.findFirstByProductIdOrderByIdDesc(product.getId()).orElseThrow(() -> new CustomException(INVALID_PRODUCT_ID));
                 if (productState.getProductStateType().equals(ProductStateType.SELLING)) {
                     sellingQuantity.getAndSet(sellingQuantity.get() + 1);
                 } else if (productState.getProductStateType().equals(ProductStateType.SOLD_OUT)) {

--- a/src/main/java/com/example/repick/domain/clothingSales/service/ClothingSalesService.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/service/ClothingSalesService.java
@@ -167,7 +167,7 @@ public class ClothingSalesService {
             // 상태가 SELLING인 경우 sellingQuantity를 증가시킨다.
             // 상태가 SOLD_OUT인 경우, 해당 state의 createdDate가 7일 이후면 soldQuantity를 증가시키고, 7일 이전이면 pendingQuantity를 증가시킨다.
             productList.forEach(product -> {
-                ProductState productState = productStateRepository.findFirstByProductIdOrderByIdDesc(product.getId()).orElseThrow(() -> new CustomException(INVALID_PRODUCT_ID);
+                ProductState productState = productStateRepository.findFirstByProductIdOrderByIdDesc(product.getId()).orElseThrow(() -> new CustomException(INVALID_PRODUCT_ID));
                 if (productState.getProductStateType().equals(ProductStateType.SELLING)) {
                     sellingQuantity.getAndSet(sellingQuantity.get() + 1);
                 } else if (productState.getProductStateType().equals(ProductStateType.SOLD_OUT)) {

--- a/src/main/java/com/example/repick/domain/product/entity/ProductOrder.java
+++ b/src/main/java/com/example/repick/domain/product/entity/ProductOrder.java
@@ -22,6 +22,7 @@ public class ProductOrder extends BaseEntity{
 
     private boolean isConfirmed;
 
+    @Enumerated(EnumType.STRING)
     private ProductOrderState productOrderState;
 
     @ManyToOne

--- a/src/main/java/com/example/repick/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/repick/domain/product/repository/ProductRepository.java
@@ -5,6 +5,7 @@ import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -13,6 +14,6 @@ public interface ProductRepository extends JpaRepository<Product, Long>, Product
     Integer countByIsBoxCollectAndClothingSalesId(Boolean isBoxCollect, Long clothingSalesId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT p FROM Product p WHERE p.id = :id")
-    List<Product> findAllByIdWithLock(List<Long> productIdList);
+    @Query("SELECT p FROM Product p WHERE p.id IN :ids")
+    List<Product> findAllByIdWithLock(List<Long> ids);
 }

--- a/src/main/java/com/example/repick/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/repick/domain/product/repository/ProductRepository.java
@@ -1,11 +1,18 @@
 package com.example.repick.domain.product.repository;
 
 import com.example.repick.domain.product.entity.Product;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
     List<Product> findProductByIsBoxCollectAndClothingSalesId(Boolean isBoxCollect, Long clothingSalesId);
     Integer countByIsBoxCollectAndClothingSalesId(Boolean isBoxCollect, Long clothingSalesId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Product p WHERE p.id = :id")
+    List<Product> findAllByIdWithLock(List<Long> productIdList);
 }

--- a/src/main/java/com/example/repick/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/repick/domain/product/repository/ProductRepository.java
@@ -5,7 +5,6 @@ import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 

--- a/src/main/java/com/example/repick/domain/product/repository/ProductStateRepository.java
+++ b/src/main/java/com/example/repick/domain/product/repository/ProductStateRepository.java
@@ -10,5 +10,5 @@ public interface ProductStateRepository extends JpaRepository<ProductState, Long
 
     List<ProductState> findByProductId(Long id);
 
-    Optional<ProductState> findFirstByProductIdOrderByIdDesc(Long productId);
+    Optional<ProductState> findFirstByProductIdOrderByCreatedDateDesc(Long productId);
 }

--- a/src/main/java/com/example/repick/domain/product/repository/ProductStateRepository.java
+++ b/src/main/java/com/example/repick/domain/product/repository/ProductStateRepository.java
@@ -4,8 +4,11 @@ import com.example.repick.domain.product.entity.ProductState;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ProductStateRepository extends JpaRepository<ProductState, Long> {
 
     List<ProductState> findByProductId(Long id);
+
+    Optional<ProductState> findFirstByProductIdOrderByIdDesc(Long productId);
 }

--- a/src/main/java/com/example/repick/domain/product/service/PaymentService.java
+++ b/src/main/java/com/example/repick/domain/product/service/PaymentService.java
@@ -8,6 +8,7 @@ import com.example.repick.domain.product.repository.PaymentRepository;
 import com.example.repick.domain.product.repository.ProductCartRepository;
 import com.example.repick.domain.product.repository.ProductOrderRepository;
 import com.example.repick.domain.product.repository.ProductRepository;
+import com.example.repick.domain.product.validator.ProductValidator;
 import com.example.repick.domain.user.entity.User;
 import com.example.repick.domain.user.repository.UserRepository;
 import com.example.repick.global.error.exception.CustomException;
@@ -36,6 +37,7 @@ public class PaymentService {
     private final ProductCartRepository productCartRepository;
     private final IamportClient iamportClient;
     private final ProductService productService;
+    private final ProductValidator productValidator;
 
     @Transactional
     public GetProductOrderPreparation prepareProductOrder(PostProductOrder postProductOrder) {
@@ -45,77 +47,85 @@ public class PaymentService {
         // 얼마 결제 예정인지 미리 등록해 결제 변조 원천 차단 (장바구니 합산, 할인된 가격 적용)
         String merchantUid = user.getProviderId() + System.currentTimeMillis();
         BigDecimal totalPrice = postProductOrder.productIds().stream()
-                .map(productId -> productRepository.findById(productId).orElseThrow(() -> new CustomException(INVALID_PRODUCT_ID)))
+                .map(productId -> {
+                    Product product = productRepository.findById(productId).orElseThrow(() -> new CustomException(INVALID_PRODUCT_ID));
+                    productValidator.validateProductState(productId, ProductStateType.SELLING);
+                    return product;
+                })
                 .map(product -> BigDecimal.valueOf(product.getDiscountPrice()))
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
 
         PrepareData prepareData = new PrepareData(merchantUid, totalPrice);
         try{
-            // 사전 결제 검증 요청
-            iamportClient.postPrepare(prepareData);
-
-            // Payment 저장
-            Payment payment = Payment.of(user.getId(), merchantUid, totalPrice);
-            paymentRepository.save(payment);
-
-            // ProductOrder 저장
-            List<ProductOrder> productOrders  = postProductOrder.productIds().stream()
-                    .map(productId -> ProductOrder.of(user.getId(), productId, payment, ProductOrderState.DEFAULT))
-                    .toList();
-            productOrderRepository.saveAll(productOrders);
-
+            iamportClient.postPrepare(prepareData);  // 사전 결제 검증 요청
         } catch (Exception e) {
             throw new CustomException(e.getMessage(), INVALID_PREPARE_DATA);
         }
 
+        // Payment 저장
+        Payment payment = Payment.of(user.getId(), merchantUid, totalPrice);
+        paymentRepository.save(payment);
+
+        // ProductOrder 저장
+        List<ProductOrder> productOrders  = postProductOrder.productIds().stream()
+                .map(productId -> ProductOrder.of(user.getId(), productId, payment, ProductOrderState.DEFAULT))
+                .toList();
+        productOrderRepository.saveAll(productOrders);
+
         return GetProductOrderPreparation.of(merchantUid, totalPrice);
     }
+
 
     @Transactional(noRollbackFor = CustomException.class)
     public Boolean validatePayment(PostPayment postPayment){
         Payment payment = paymentRepository.findByMerchantUid(postPayment.merchantUid())
                 .orElseThrow(() -> new CustomException(INVALID_PAYMENT_ID));
 
+        // Pessimistic Lock - 이 트랜잭션이 끝날 때까지 다른 트랜잭션에서 해당 데이터(products)에 대한 접근을 막음
+        // 이미 처리된 주문인지 확인 (동시 결제 방지)
+        List<ProductOrder> productOrders = productOrderRepository.findByPayment(payment);
+        List<Product> products = productRepository.findAllByIdWithLock(productOrders.stream().map(ProductOrder::getProductId).toList());
+        products.forEach(product -> {
+            try{
+                productValidator.validateProductState(product.getId(), ProductStateType.SELLING);
+            }
+            catch (CustomException e){
+                if(e.getErrorCode() == PRODUCT_NOT_DESIRED_STATE){
+                    cancelPayment(payment);
+                    throw new CustomException(PRODUCT_SOLD_OUT);
+                }
+                throw e;
+            }
+        });
+
         // 이미 처리된 결제번호인지 확인
         if (paymentRepository.findByIamportUid(postPayment.iamportUid()).isPresent()) {
             throw new CustomException(DUPLICATE_PAYMENT);
         }
-        try{
-            com.siot.IamportRestClient.response.Payment paymentResponse = iamportClient.paymentByImpUid(postPayment.iamportUid()).getResponse();
 
-            // 가맹점 주문번호 일치 확인
-            if (!paymentResponse.getMerchantUid().equals(postPayment.merchantUid())) {
-                throw new CustomException(INVALID_PAYMENT_ID);
-            }
+        // 포트원 서버에서 결제 정보 가져오기
+        com.siot.IamportRestClient.response.Payment paymentResponse = getPaymentResponse(postPayment.iamportUid());
 
-            switch (paymentResponse.getStatus().toUpperCase()) {
-                case "READY", "CANCELLED", "FAILED"  -> {
-                    // 가상계좌 발급한다면 "READY" case 수정
-                    payment.completePayment(PaymentStatus.fromValue(paymentResponse.getStatus().toUpperCase()), postPayment.iamportUid(), postPayment.address());
-                    paymentRepository.save(payment);
-                    throw new CustomException(INVALID_PAYMENT_STATUS);
-                }
-                case "PAID" -> {
-                    // 결제금액 확인 (데이터베이스에 저장되어 있는 상품 가격과 비교)
-                    if (paymentResponse.getAmount().compareTo(payment.getAmount()) != 0) {
-                        CancelData cancelData = new CancelData(paymentResponse.getImpUid(), true);
-                        iamportClient.cancelPaymentByImpUid(cancelData);
-
-                        payment.updatePaymentStatus(PaymentStatus.CANCELLED);
-                        paymentRepository.save(payment);
-
-                        throw new CustomException(WRONG_PAYMENT_AMOUNT);
-                    }
-                }
-                default -> throw new CustomException(INVALID_PAYMENT_STATUS);
-            }
-
-        } catch (CustomException e){
-            throw e;
-        } catch (IamportResponseException | IOException e) {
+        // 가맹점 주문번호 일치 확인
+        if (!paymentResponse.getMerchantUid().equals(postPayment.merchantUid())) {
             throw new CustomException(INVALID_PAYMENT_ID);
-        } catch(Exception e){
-            throw new RuntimeException(e);
+        }
+
+        switch (paymentResponse.getStatus().toUpperCase()) {
+            case "READY", "CANCELLED", "FAILED"  -> {
+                // 가상계좌 발급한다면 "READY" case 수정
+                payment.completePayment(PaymentStatus.fromValue(paymentResponse.getStatus().toUpperCase()), postPayment.iamportUid(), postPayment.address());
+                paymentRepository.save(payment);
+                throw new CustomException(INVALID_PAYMENT_STATUS);
+            }
+            case "PAID" -> {
+                // 결제금액 확인 (데이터베이스에 저장되어 있는 상품 가격과 비교)
+                if (paymentResponse.getAmount().compareTo(payment.getAmount()) != 0) {
+                    cancelPayment(payment);
+                    throw new CustomException(WRONG_PAYMENT_AMOUNT);
+                }
+            }
+            default -> throw new CustomException(INVALID_PAYMENT_STATUS);
         }
 
         // 유효한 결제 -> Payment 저장
@@ -123,7 +133,6 @@ public class PaymentService {
         paymentRepository.save(payment);
 
         // ProductOrderState 업데이트, 장바구니 삭제, ProductSellingState 추가
-        List<ProductOrder> productOrders = productOrderRepository.findByPayment(payment);
         productOrders.forEach(productOrder -> {
             productOrder.updateProductOrderState(ProductOrderState.PAYMENT_COMPLETED);
             productCartRepository.deleteByUserIdAndProductId(productOrder.getUserId(), productOrder.getProductId());
@@ -131,6 +140,25 @@ public class PaymentService {
         });
 
         return true;
+    }
+
+    private com.siot.IamportRestClient.response.Payment getPaymentResponse(String impUid) {
+        try {
+            return iamportClient.paymentByImpUid(impUid).getResponse();
+        } catch (IamportResponseException | IOException e) {
+            throw new CustomException(INVALID_PAYMENT_ID);
+        }
+    }
+
+    private void cancelPayment(Payment payment) {
+        CancelData cancelData = new CancelData(payment.getIamportUid(), true);
+        try {
+            iamportClient.cancelPaymentByImpUid(cancelData);
+        } catch (IamportResponseException | IOException e) {
+            throw new CustomException(INVALID_PAYMENT_ID);
+        }
+        payment.updatePaymentStatus(PaymentStatus.CANCELLED);
+        paymentRepository.save(payment);
     }
 
     @Transactional
@@ -150,6 +178,7 @@ public class PaymentService {
         return true;
     }
 
+    @Transactional
     public void addPointToSeller(ProductOrder productOrder){
         long profit = productOrder.getPayment().getAmount().longValue();
         if (profit >= 300000) {

--- a/src/main/java/com/example/repick/domain/product/service/PaymentService.java
+++ b/src/main/java/com/example/repick/domain/product/service/PaymentService.java
@@ -88,6 +88,7 @@ public class PaymentService {
             ProductState productState = productStateRepository.findFirstByProductIdOrderByCreatedDateDesc(product.getId())
                     .orElseThrow(() -> new CustomException(PRODUCT_STATE_NOT_FOUND));
             if(productState.getProductStateType() != ProductStateType.SELLING){
+                cancelPayment(payment);
                 throw new CustomException(PRODUCT_SOLD_OUT);
             }
         });

--- a/src/main/java/com/example/repick/domain/product/service/PaymentService.java
+++ b/src/main/java/com/example/repick/domain/product/service/PaymentService.java
@@ -34,7 +34,6 @@ public class PaymentService {
     private final ProductOrderRepository productOrderRepository;
     private final ProductCartRepository productCartRepository;
     private final IamportClient iamportClient;
-    private final ProductService productService;
     private final ProductValidator productValidator;
     private final ProductStateRepository productStateRepository;
 

--- a/src/main/java/com/example/repick/domain/product/service/PaymentService.java
+++ b/src/main/java/com/example/repick/domain/product/service/PaymentService.java
@@ -85,7 +85,7 @@ public class PaymentService {
         List<ProductOrder> productOrders = productOrderRepository.findByPayment(payment);
         List<Product> products = productRepository.findAllByIdWithLock(productOrders.stream().map(ProductOrder::getProductId).toList());
         products.forEach(product -> {
-            ProductState productState = productStateRepository.findFirstByProductIdOrderByIdDesc(product.getId())
+            ProductState productState = productStateRepository.findFirstByProductIdOrderByCreatedDateDesc(product.getId())
                     .orElseThrow(() -> new CustomException(PRODUCT_STATE_NOT_FOUND));
             if(productState.getProductStateType() != ProductStateType.SELLING){
                 throw new CustomException(PRODUCT_SOLD_OUT);
@@ -216,7 +216,7 @@ public class PaymentService {
         System.out.println("Thread " + Thread.currentThread().getName() + " has locked products: " + productIds + ". Wait time: " + (endTime - startTime) + "ms");
 
         products.forEach(product -> {
-            ProductState productState = productStateRepository.findFirstByProductIdOrderByIdDesc(product.getId())
+            ProductState productState = productStateRepository.findFirstByProductIdOrderByCreatedDateDesc(product.getId())
                     .orElseThrow(() -> new CustomException(PRODUCT_STATE_NOT_FOUND));
             if(productState.getProductStateType() != ProductStateType.SELLING){
                 throw new CustomException(PRODUCT_SOLD_OUT);

--- a/src/main/java/com/example/repick/domain/product/service/ProductService.java
+++ b/src/main/java/com/example/repick/domain/product/service/ProductService.java
@@ -39,7 +39,7 @@ public class ProductService {
     private final UserRepository userRepository;
     private final ProductLikeRepository productLikeRepository;
     private final ProductCartRepository productCartRepository;
-    private final ProductStateRepository productSellingStateRepository;
+    private final ProductStateRepository productStateRepository;
     private final ProductValidator productValidator;
 
     private String uploadImage(List<MultipartFile> images, Product product) {
@@ -76,7 +76,7 @@ public class ProductService {
     }
 
     public void addProductSellingState(Long productId, ProductStateType productStateType) {
-        productSellingStateRepository.save(ProductState.of(productId, productStateType));
+        productStateRepository.save(ProductState.of(productId, productStateType));
     }
 
     @Transactional
@@ -128,7 +128,7 @@ public class ProductService {
         productStyleRepository.findByProductId(product.getId()).forEach(ProductStyle::delete);
 
         // productSellingState
-        productSellingStateRepository.findByProductId(product.getId()).forEach(ProductState::delete);
+        productStateRepository.findByProductId(product.getId()).forEach(ProductState::delete);
 
         return ProductResponse.fromProduct(product);
     }
@@ -296,13 +296,6 @@ public class ProductService {
 
     public List<Product> findByClothingSales(Boolean isBoxCollect, Long clothingSlaesId) {
         return productRepository.findProductByIsBoxCollectAndClothingSalesId(isBoxCollect, clothingSlaesId);
-    }
-
-    public ProductState getProductSellingState(Long productId) {
-        return productSellingStateRepository.findByProductId(productId)
-                .stream()
-                .max((o1, o2) -> (int) (o1.getId() - o2.getId()))
-                .orElseThrow(() -> new CustomException(INVALID_PRODUCT_ID));
     }
 
     public List<GetClassificationEach> getProductStyleTypes() {

--- a/src/main/java/com/example/repick/domain/product/validator/ProductValidator.java
+++ b/src/main/java/com/example/repick/domain/product/validator/ProductValidator.java
@@ -10,7 +10,9 @@ import com.example.repick.domain.product.repository.ProductStateRepository;
 import com.example.repick.global.error.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Objects;
 
 import static com.example.repick.global.error.exception.ErrorCode.*;
@@ -23,15 +25,9 @@ public class ProductValidator {
     private final BoxCollectRepository boxCollectRepository;
 
     public void validateProductState(Long productId, ProductStateType productStateType) {
-
-        // find the most recently created product state
-        ProductState productStateList = productStateRepository.findByProductId(productId)
-                .stream()
-                .reduce((first, second) -> second)
+        ProductState productState = productStateRepository.findFirstByProductIdOrderByIdDesc(productId)
                 .orElseThrow(() -> new CustomException(PRODUCT_STATE_NOT_FOUND));
-
-
-        if (productStateList.getProductStateType() != productStateType) {
+        if (productState.getProductStateType() != productStateType) {
             throw new CustomException(PRODUCT_NOT_DESIRED_STATE);
         }
     }

--- a/src/main/java/com/example/repick/domain/product/validator/ProductValidator.java
+++ b/src/main/java/com/example/repick/domain/product/validator/ProductValidator.java
@@ -10,7 +10,6 @@ import com.example.repick.domain.product.repository.ProductStateRepository;
 import com.example.repick.global.error.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Objects;

--- a/src/main/java/com/example/repick/domain/product/validator/ProductValidator.java
+++ b/src/main/java/com/example/repick/domain/product/validator/ProductValidator.java
@@ -11,7 +11,6 @@ import com.example.repick.global.error.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
 import java.util.Objects;
 
 import static com.example.repick.global.error.exception.ErrorCode.*;

--- a/src/main/java/com/example/repick/domain/product/validator/ProductValidator.java
+++ b/src/main/java/com/example/repick/domain/product/validator/ProductValidator.java
@@ -24,7 +24,7 @@ public class ProductValidator {
     private final BoxCollectRepository boxCollectRepository;
 
     public void validateProductState(Long productId, ProductStateType productStateType) {
-        ProductState productState = productStateRepository.findFirstByProductIdOrderByIdDesc(productId)
+        ProductState productState = productStateRepository.findFirstByProductIdOrderByCreatedDateDesc(productId)
                 .orElseThrow(() -> new CustomException(PRODUCT_STATE_NOT_FOUND));
         if (productState.getProductStateType() != productStateType) {
             throw new CustomException(PRODUCT_NOT_DESIRED_STATE);

--- a/src/main/java/com/example/repick/global/error/exception/CustomException.java
+++ b/src/main/java/com/example/repick/global/error/exception/CustomException.java
@@ -16,4 +16,8 @@ public class CustomException extends RuntimeException {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
 }

--- a/src/main/java/com/example/repick/global/error/exception/CustomException.java
+++ b/src/main/java/com/example/repick/global/error/exception/CustomException.java
@@ -16,8 +16,4 @@ public class CustomException extends RuntimeException {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
-
-    public ErrorCode getErrorCode() {
-        return errorCode;
-    }
 }

--- a/src/main/java/com/example/repick/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/example/repick/global/error/exception/ErrorCode.java
@@ -65,6 +65,7 @@ public enum ErrorCode {
     INVALID_PAYMENT_STATUS(400, "P045", "결제 상태가 존재하지 않거나, 미결제, 결제취소, 결제실패 중 하나입니다."),
     PRODUCT_ORDER_NOT_FOUND(404, "P046", "존재하지 않는 상품 주문 ID입니다."),
     PRODUCT_ORDER_ALREADY_CONFIRMED(400, "P047", "이미 구매를 확정한 상품입니다."),
+    PRODUCT_SOLD_OUT(400, "P048", "품절된 상품이 포함되어 있습니다"),
     // SMS Verification
     USER_SMS_VERIFICATION_NOT_FOUND(404, "A001", "인증번호가 만료되었거나 존재하지 않습니다."),
     USER_SMS_VERIFICATION_EXPIRED(400, "A002", "인증번호가 만료되었습니다."),

--- a/src/test/java/com/example/repick/payment/PaymentServiceTest.java
+++ b/src/test/java/com/example/repick/payment/PaymentServiceTest.java
@@ -60,6 +60,18 @@ public class PaymentServiceTest {
         productStateRepository.save(productState1);
         productStateRepository.save(productState2);
     }
+
+    @AfterEach
+    public void cleanup() {
+        productRepository.delete(product1);
+        productRepository.delete(product2);
+        productStateRepository.deleteAll(productStateRepository.findByProductId(product1.getId()));
+        productStateRepository.deleteAll(productStateRepository.findByProductId(product2.getId()));
+        productOrderRepository.deleteAll();
+        paymentRepository.deleteAll();
+    }
+
+
     @Test
     public void testConcurrentPayments() throws InterruptedException {
         int numberOfThreads = 3;
@@ -96,7 +108,7 @@ public class PaymentServiceTest {
                     productOrderRepository.save(productOrder2);
 
                     PostPayment postPayment = new PostPayment("iamportUid" + userId, "merchantUid" + userId, new Address());
-                    return paymentService.validatePaymentForTest(postPayment);  // iamportClient 통신 부분 제외한 테스트용 코드 작성
+                    return paymentService.validatePaymentForTest(postPayment);  // 테스트용 서비스
                 } catch (Exception e) {
                     System.out.println("Exception occurred while processing payment: " + userId + "\n" + e.getMessage());
                     return false;

--- a/src/test/java/com/example/repick/payment/PaymentServiceTest.java
+++ b/src/test/java/com/example/repick/payment/PaymentServiceTest.java
@@ -1,0 +1,131 @@
+package com.example.repick.payment;
+
+import com.example.repick.domain.product.dto.productOrder.PostPayment;
+import com.example.repick.domain.product.entity.*;
+import com.example.repick.domain.product.repository.PaymentRepository;
+import com.example.repick.domain.product.repository.ProductOrderRepository;
+import com.example.repick.domain.product.repository.ProductRepository;
+import com.example.repick.domain.product.repository.ProductStateRepository;
+import com.example.repick.domain.product.service.PaymentService;
+import com.example.repick.global.entity.Address;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+public class PaymentServiceTest {
+
+    @Autowired
+    private PaymentService paymentService;
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @Autowired
+    private ProductOrderRepository productOrderRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private ProductStateRepository productStateRepository;
+
+    private Product product1;
+    private Product product2;
+
+    @BeforeEach
+    public void setup() {
+        // 테스트에 필요한 데이터 셋업
+        product1 = Product.builder().discountPrice(1000L).build();
+        product2 = Product.builder().discountPrice(2000L).build();
+        productRepository.save(product1);
+        productRepository.save(product2);
+
+        ProductState productState1 = ProductState.builder()
+                .productId(product1.getId())
+                .productStateType(ProductStateType.SELLING)
+                .build();
+        ProductState productState2 = ProductState.builder()
+                .productId(product2.getId())
+                .productStateType(ProductStateType.SELLING)
+                .build();
+        productStateRepository.save(productState1);
+        productStateRepository.save(productState2);
+    }
+    @Test
+    public void testConcurrentPayments() throws InterruptedException {
+        int numberOfThreads = 3;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        List<Callable<Boolean>> tasks = new ArrayList<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            int userId = i + 1;
+            tasks.add(() -> {
+                System.out.println("Thread " + userId + " is ready.");
+                latch.await(); // 모든 스레드가 준비될 때까지 대기
+                try {
+                    System.out.println("Thread " + userId + " is processing.");
+                    Payment payment = Payment.builder()
+                            .merchantUid("merchantUid" + userId)
+                            .paymentStatus(PaymentStatus.READY)
+                            .build();
+                    paymentRepository.save(payment);
+
+                    ProductOrder productOrder1 = ProductOrder.builder()
+                            .payment(payment)
+                            .userId((long) userId)
+                            .productId(product1.getId())
+                            .productOrderState(ProductOrderState.DEFAULT)
+                            .build();
+                    ProductOrder productOrder2 = ProductOrder.builder()
+                            .payment(payment)
+                            .userId((long) userId)
+                            .productId(product2.getId())
+                            .productOrderState(ProductOrderState.DEFAULT)
+                            .build();
+                    productOrderRepository.save(productOrder1);
+                    productOrderRepository.save(productOrder2);
+
+                    PostPayment postPayment = new PostPayment("iamportUid" + userId, "merchantUid" + userId, new Address());
+                    return paymentService.validatePaymentForTest(postPayment);  // iamportClient 통신 부분 제외한 테스트용 코드 작성
+                } catch (Exception e) {
+                    System.out.println("Exception occurred while processing payment: " + userId + "\n" + e.getMessage());
+                    return false;
+                }
+            });
+        }
+
+        System.out.println("All threads are ready to start.");
+        latch.countDown(); // 모든 스레드가 동시에 실행되도록
+
+        List<Future<Boolean>> futures = executorService.invokeAll(tasks);
+        executorService.shutdown();
+        executorService.awaitTermination(1, TimeUnit.MINUTES);
+        System.out.println("All threads are completed.");
+
+        int successCount = 0;
+        for (Future<Boolean> future : futures) {
+            try {
+                if (future.get()) {
+                    successCount++;
+                }
+            } catch (ExecutionException e) {
+                System.out.println("ExecutionException occurred while processing future result: " + e.getMessage());
+                e.printStackTrace();
+            }
+        }
+
+        // 성공적으로 처리된 결제가 한 번이어야 함
+        System.out.println("Number of successful payments: " + successCount);
+        assertTrue(successCount == 1, "동시성 테스트 실패: 성공적으로 처리된 결제는 한 번이어야 합니다.");
+    }
+}


### PR DESCRIPTION
# 결제 시 동시성 문제 수정

<img width="334" alt="스크린샷 2024-05-29 오전 5 56 31" src="https://github.com/Repick-official/repick-server-v2/assets/86969518/076ba8cb-d25e-46b0-a52c-f66c8503f36d">

### 동시성 이슈 해결
- Product 조회 시 Pessimistic Lock 적용
   - 하나의 트랜잭션에서 product 접근 시 다른 트랜잭션에서 같은 product 접근 불가
   - 이전 트랜잭션이 완료될 때까지 대기함
- Transaction isolation level = READ_COMMITTED
   - MySQL의 Default isolation level은 REPEATABLE_READ
   - 먼저 수행된 트랜잭션이 '판매 완료' 처리하는 데이터를 읽기 위해
- validatePayment(결제 사후 검증)에서 product의 판매 상태를 검증하는 부분을 추가
   - productId만 사용해도 로직은 가능하지만, Pessimistic Lock을 적용하기 위해 Product 테이블에서 findAllByIdWithLock 으로 조회
   - 이미 판매된 상품이라면 결제 취소 
- 동시성 테스트하기 위해 iamport 통신 부분 제외한 validatePaymentForTest 서비스 및 테스트 코드 작성
   - 트랜잭션 격리 및 결과 검증 완료
   
### 그 외 수정
- 결제 사전 검증, 사후 검증에서 iamport 요청하는 부분 메소드화
- 상품의 가장 최근 ProductState 가져오기
```java
public interface ProductStateRepository extends JpaRepository<ProductState, Long> {

    Optional<ProductState> findFirstByProductIdOrderByCreatedDateDesc(Long productId);
}

```
- ProductService의 getProductSellingState, ProductValidator의 validateProduct에서 stream 사용해 비교하던 부분 삭제
