### PR TITLE
feature: add clothing sales count

### DIFF
--- a/src/main/java/com/example/repick/domain/clothingSales/api/ClothingSalesController.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/api/ClothingSalesController.java
@@ -132,26 +132,15 @@ public class ClothingSalesController {
         return SuccessResponse.success(clothingSalesService.getSellingClothingSales());
     }
 
-    @Operation(summary = "박스: 판매 가능한 상품 보기", description = """
-            박스 수거 신청 건에 대한 판매 가능 상품을 조회합니다.
+    @Operation(summary = "수거: 판매 가능한 상품 보기", description = """
+            수거 신청 건에 대한 판매 가능 상품을 조회합니다.
             - productList: 상품 리스트
             - requestedQuantity: 신청한 의류 수량
             - productQuantity: 판매 가능한 의류 수량
             """)
-    @GetMapping("/products/box/{boxCollectId}")
-    public SuccessResponse<GetProductListByClothingSales> getProductsByBoxCollectId(@PathVariable Long boxCollectId) {
-        return SuccessResponse.success(boxService.getProductsByBoxId(boxCollectId));
-    }
-
-    @Operation(summary = "백: 판매 가능한 상품 보기", description = """
-            백 수거 신청 건에 대한 판매 가능 상품을 조회합니다.
-            - productList: 상품 리스트
-            - requestedQuantity: 신청한 의류 수량
-            - productQuantity: 판매 가능한 의류 수량
-            """)
-    @GetMapping("/products/bag/{bagInitId}")
-    public SuccessResponse<GetProductListByClothingSales> getProductsByBagInitId(@PathVariable Long bagInitId) {
-        return SuccessResponse.success(bagService.getProductsByBagInitId(bagInitId));
+    @GetMapping("/products/{clothingSalesCount}")
+    public SuccessResponse<GetProductListByClothingSales> getProductsByClothingSalesCount(@PathVariable Integer clothingSalesCount) {
+        return SuccessResponse.success(clothingSalesService.getProductsByClothingSalesCount(clothingSalesCount));
     }
 
     @Operation(summary = "상품 가격 입력하기", description = """
@@ -176,9 +165,9 @@ public class ClothingSalesController {
             - clothingSalesId: 수거 ID
             
             """)
-    @PostMapping("/products/start-selling")
-    public SuccessResponse<Boolean> startSellingBox(@RequestBody PostClothingSales postStartSelling) {
-        return SuccessResponse.success(clothingSalesService.startSelling(postStartSelling));
+    @PostMapping("/products/start-selling/{clothingSalesCount}")
+    public SuccessResponse<Boolean> startSelling(@PathVariable Integer clothingSalesCount) {
+        return SuccessResponse.success(clothingSalesService.startSelling(clothingSalesCount));
     }
 
     // TODO: ADMIN ACCESS

--- a/src/main/java/com/example/repick/domain/clothingSales/api/ClothingSalesController.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/api/ClothingSalesController.java
@@ -107,6 +107,7 @@ public class ClothingSalesController {
     @Operation(summary = "옷장 정리 통합 조회: 진행 중인 수거", description = """
             옷장 정리 통합 조회: 진행 중인 수거, 신청 완료일 순으로 정렬되어 리스트로 반환합니다.
             - id: 수거 ID, '백 수거 요청' 시 '백 요청 ID'를 조회하기 위해 사용됩니다.
+            - clothingSalesCount: 수거 회차(각각의 유저에 대해 고유한 값입니다).
             - type: 박스/백
             - requestDate: 신청 완료일
             - bagArriveDate: 백 도착일 (박스의 경우 항상 null)
@@ -121,6 +122,7 @@ public class ClothingSalesController {
     @Operation(summary = "옷장 정리 통합 조회: 판매 중인 옷장", description = """
             옷장 정리 통합 조회: 판매 중인 옷장, 신청 완료일 순으로 정렬되어 리스트로 반환합니다.
             - id: 수거 ID
+            - clothingSalesCount: 수거 회차(각각의 유저에 대해 고유한 값입니다).
             - clothingSalesPeriod: 신청 완료일 ~ 판매 진행 시작일
             - sellingQuantity: 판매 중인 의류 수량
             - pendingQuantity: 구매 확정 대기 수량
@@ -161,8 +163,7 @@ public class ClothingSalesController {
             수거 신청 건에 대한 옷장 판매를 시작합니다.
             **가격이 등록되지 않은 상품이 있다면 판매 시작이 불가합니다**
             
-            - isBoxCollect: 박스 수거 여부 (true: 박스, false: 백)
-            - clothingSalesId: 수거 ID
+            - clothingSalesCount: 수거 회차
             
             """)
     @PostMapping("/products/start-selling/{clothingSalesCount}")

--- a/src/main/java/com/example/repick/domain/clothingSales/dto/GetPendingClothingSales.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/dto/GetPendingClothingSales.java
@@ -4,15 +4,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record GetPendingClothingSales(
         @Schema(description = "수거 ID", example = "1") Long id,
+        @Schema(description = "옷장 정리 회차", example = "1") Integer clothingSalesCount,
         @Schema(description = "타입(박스/백)", example = "박스") String type,
         @Schema(description = "신청 완료일", example = "24.09.15") String requestDate,
         @Schema(description = "백 도착일", example = "24.09.16") String bagArriveDate,
         @Schema(description = "수거 완료일", example = "24.09.17") String collectDate,
         @Schema(description = "상품화 완료일", example = "24.09.18") String productDate
 ) {
-    public static GetPendingClothingSales of(Long id, String type, String requestDate, String bagArriveDate, String collectDate, String productDate) {
+    public static GetPendingClothingSales of(Long id, Integer clothingSalesCount, String type, String requestDate, String bagArriveDate, String collectDate, String productDate) {
         return new GetPendingClothingSales(
                 id,
+                clothingSalesCount,
                 type,
                 requestDate,
                 bagArriveDate,

--- a/src/main/java/com/example/repick/domain/clothingSales/dto/GetSellingClothingSales.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/dto/GetSellingClothingSales.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record GetSellingClothingSales(
         @Schema(description = "수거 ID", example = "1") Long id,
+        @Schema(description = "옷장 정리 회차", example = "1") Integer clothingSalesCount,
         @Schema(description = "박스 수거 여부", example = "true") Boolean isBoxCollect,
         @Schema(description = "판매 진행 시작일 ~ +90일", example = "24.01.05-24.04.05") String clothingSalesPeriod,
         @Schema(description = "판매 중인 의류 수량", example = "43") Integer sellingQuantity,

--- a/src/main/java/com/example/repick/domain/clothingSales/dto/GetSellingClothingSales.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/dto/GetSellingClothingSales.java
@@ -10,6 +10,6 @@ public record GetSellingClothingSales(
         @Schema(description = "판매 중인 의류 수량", example = "43") Integer sellingQuantity,
         @Schema(description = "구매 확정 대기 수량", example = "7") Integer pendingQuantity,
         @Schema(description = "구매 확정 완료 수량", example = "36") Integer soldQuantity,
-        @Schema(description = "총 포인트", example = "2300") Integer totalPoint
+        @Schema(description = "총 포인트", example = "2300") Long totalPoint
 ) {
 }

--- a/src/main/java/com/example/repick/domain/clothingSales/dto/GetSellingClothingSales.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/dto/GetSellingClothingSales.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record GetSellingClothingSales(
         @Schema(description = "수거 ID", example = "1") Long id,
         @Schema(description = "옷장 정리 회차", example = "1") Integer clothingSalesCount,
-        @Schema(description = "박스 수거 여부", example = "true") Boolean isBoxCollect,
         @Schema(description = "판매 진행 시작일 ~ +90일", example = "24.01.05-24.04.05") String clothingSalesPeriod,
         @Schema(description = "판매 중인 의류 수량", example = "43") Integer sellingQuantity,
         @Schema(description = "구매 확정 대기 수량", example = "7") Integer pendingQuantity,

--- a/src/main/java/com/example/repick/domain/clothingSales/dto/PostBagCollect.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/dto/PostBagCollect.java
@@ -2,6 +2,7 @@ package com.example.repick.domain.clothingSales.dto;
 
 import com.example.repick.domain.clothingSales.entity.BagCollect;
 import com.example.repick.domain.clothingSales.entity.BagInit;
+import com.example.repick.domain.user.entity.User;
 import com.example.repick.global.entity.Address;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.web.multipart.MultipartFile;
@@ -18,8 +19,9 @@ public record PostBagCollect (
         @Schema(description = "희망 수거 날짜", example = "2021-09-15") String collectionDate
 
 ) {
-    public BagCollect toEntity(BagInit bagInit) {
+    public BagCollect toEntity(BagInit bagInit, User user) {
         return BagCollect.builder()
+                .user(user)
                 .bagInit(bagInit)
                 .bagQuantity(bagQuantity)
                 .address(new Address(postalCode, mainAddress, detailAddress))

--- a/src/main/java/com/example/repick/domain/clothingSales/dto/PostBagInit.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/dto/PostBagInit.java
@@ -21,6 +21,7 @@ public record PostBagInit(
                 .bagQuantity(bagQuantity)
                 .address(new Address(postalCode, mainAddress, detailAddress))
                 .clothingSalesCount(clothingSalesCount)
+                .point(0L)
                 .build();
     }
 

--- a/src/main/java/com/example/repick/domain/clothingSales/dto/PostBagInit.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/dto/PostBagInit.java
@@ -15,11 +15,12 @@ public record PostBagInit(
 
 ) {
 
-    public BagInit toEntity(User user) {
+    public BagInit toEntity(User user, Integer clothingSalesCount) {
         return BagInit.builder()
                 .user(user)
                 .bagQuantity(bagQuantity)
                 .address(new Address(postalCode, mainAddress, detailAddress))
+                .clothingSalesCount(clothingSalesCount)
                 .build();
     }
 

--- a/src/main/java/com/example/repick/domain/clothingSales/dto/PostBoxCollect.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/dto/PostBoxCollect.java
@@ -17,12 +17,13 @@ public record PostBoxCollect (
         @Schema(description = "희망 수거 날짜", example = "2021-09-15") String collectionDate
 
 ) {
-    public BoxCollect toEntity(User user) {
+    public BoxCollect toEntity(User user, Integer clothingSalesCount) {
         return BoxCollect.builder()
                 .user(user)
                 .boxQuantity(boxQuantity)
                 .address(new Address(postalCode, mainAddress, detailAddress))
                 .collectionDate(LocalDate.parse(collectionDate))
+                .clothingSalesCount(clothingSalesCount)
                 .build();
     }
 }

--- a/src/main/java/com/example/repick/domain/clothingSales/dto/PostBoxCollect.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/dto/PostBoxCollect.java
@@ -24,6 +24,7 @@ public record PostBoxCollect (
                 .address(new Address(postalCode, mainAddress, detailAddress))
                 .collectionDate(LocalDate.parse(collectionDate))
                 .clothingSalesCount(clothingSalesCount)
+                .point(0L)
                 .build();
     }
 }

--- a/src/main/java/com/example/repick/domain/clothingSales/dto/PostClothingSales.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/dto/PostClothingSales.java
@@ -3,7 +3,7 @@ package com.example.repick.domain.clothingSales.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record PostClothingSales(
-        @Schema(description = "수거 ID", example = "1") Long clothingSalesId,
-        @Schema(description = "박스 수거 여부", example = "true") Boolean isBoxCollect
+        @Schema(description = "유저 ID", example = "1") Long userId,
+        @Schema(description = "수거 회차", example = "3") Integer clothingSalesCount
 ) {
 }

--- a/src/main/java/com/example/repick/domain/clothingSales/entity/BagInit.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/entity/BagInit.java
@@ -42,17 +42,25 @@ public class BagInit extends BaseEntity {
     @Column(name = "clothing_sales_count")
     private Integer clothingSalesCount;
 
+    @Column(name = "point")
+    private Long point;
+
     @Builder
-    public BagInit(User user, Address address, Integer bagQuantity, String imageUrl, Integer clothingSalesCount) {
+    public BagInit(User user, Address address, Integer bagQuantity, String imageUrl, Integer clothingSalesCount, Long point) {
         this.user = user;
         this.address = address;
         this.bagQuantity = bagQuantity;
         this.imageUrl = imageUrl;
         this.clothingSalesCount = clothingSalesCount;
+        this.point = point;
     }
 
     public void updateImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;
+    }
+
+    public void updatePoint(long point) {
+        this.point = point;
     }
 
 }

--- a/src/main/java/com/example/repick/domain/clothingSales/entity/BagInit.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/entity/BagInit.java
@@ -39,12 +39,16 @@ public class BagInit extends BaseEntity {
     @OneToOne(mappedBy = "bagInit", cascade = CascadeType.ALL)
     private BagCollect bagCollect;
 
+    @Column(name = "clothing_sales_count")
+    private Integer clothingSalesCount;
+
     @Builder
-    public BagInit(User user, Address address, Integer bagQuantity, String imageUrl) {
+    public BagInit(User user, Address address, Integer bagQuantity, String imageUrl, Integer clothingSalesCount) {
         this.user = user;
         this.address = address;
         this.bagQuantity = bagQuantity;
         this.imageUrl = imageUrl;
+        this.clothingSalesCount = clothingSalesCount;
     }
 
     public void updateImageUrl(String imageUrl) {

--- a/src/main/java/com/example/repick/domain/clothingSales/entity/BoxCollect.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/entity/BoxCollect.java
@@ -40,18 +40,26 @@ public class BoxCollect extends BaseEntity {
     @Column(name = "clothing_sales_count")
     private Integer clothingSalesCount;
 
+    @Column(name = "point")
+    private Long point;
+
     @Builder
-    public BoxCollect(User user, Address address, Integer boxQuantity, String imageUrl, LocalDate collectionDate, Integer clothingSalesCount) {
+    public BoxCollect(User user, Address address, Integer boxQuantity, String imageUrl, LocalDate collectionDate, Integer clothingSalesCount, Long point) {
         this.user = user;
         this.address = address;
         this.boxQuantity = boxQuantity;
         this.imageUrl = imageUrl;
         this.collectionDate = collectionDate;
         this.clothingSalesCount = clothingSalesCount;
+        this.point = point;
     }
 
     public void updateImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;
+    }
+
+    public void updatePoint(long point) {
+        this.point = point;
     }
 
 }

--- a/src/main/java/com/example/repick/domain/clothingSales/entity/BoxCollect.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/entity/BoxCollect.java
@@ -37,13 +37,17 @@ public class BoxCollect extends BaseEntity {
     @OneToMany(mappedBy = "boxCollect", cascade = CascadeType.ALL)
     private List<BoxCollectState> boxCollectStateList;
 
+    @Column(name = "clothing_sales_count")
+    private Integer clothingSalesCount;
+
     @Builder
-    public BoxCollect(User user, Address address, Integer boxQuantity, String imageUrl, LocalDate collectionDate) {
+    public BoxCollect(User user, Address address, Integer boxQuantity, String imageUrl, LocalDate collectionDate, Integer clothingSalesCount) {
         this.user = user;
         this.address = address;
         this.boxQuantity = boxQuantity;
         this.imageUrl = imageUrl;
         this.collectionDate = collectionDate;
+        this.clothingSalesCount = clothingSalesCount;
     }
 
     public void updateImageUrl(String imageUrl) {

--- a/src/main/java/com/example/repick/domain/clothingSales/repository/BagInitRepository.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/repository/BagInitRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface BagInitRepository extends JpaRepository<BagInit, Long> {
     List<BagInit> findByUserId(Long userId);
+    Integer countByUserId(Long userId);
 }

--- a/src/main/java/com/example/repick/domain/clothingSales/repository/BagInitRepository.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/repository/BagInitRepository.java
@@ -4,8 +4,11 @@ import com.example.repick.domain.clothingSales.entity.BagInit;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BagInitRepository extends JpaRepository<BagInit, Long> {
     List<BagInit> findByUserId(Long userId);
     Integer countByUserId(Long userId);
+
+    Optional<BagInit> findByUserIdAndClothingSalesCount(Long userId, Integer clothingSalesCount);
 }

--- a/src/main/java/com/example/repick/domain/clothingSales/repository/BoxCollectRepository.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/repository/BoxCollectRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface BoxCollectRepository extends JpaRepository<BoxCollect, Long> {
     List<BoxCollect> findByUserId(Long userId);
 
+    Integer countByUserId(Long userId);
 }

--- a/src/main/java/com/example/repick/domain/clothingSales/repository/BoxCollectRepository.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/repository/BoxCollectRepository.java
@@ -4,9 +4,12 @@ import com.example.repick.domain.clothingSales.entity.BoxCollect;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BoxCollectRepository extends JpaRepository<BoxCollect, Long> {
     List<BoxCollect> findByUserId(Long userId);
 
     Integer countByUserId(Long userId);
+
+    Optional<BoxCollect> findByUserIdAndClothingSalesCount(Long userId, Integer clothingSalesCount);
 }

--- a/src/main/java/com/example/repick/domain/clothingSales/service/BagService.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/service/BagService.java
@@ -2,10 +2,7 @@ package com.example.repick.domain.clothingSales.service;
 
 import com.example.repick.domain.clothingSales.dto.*;
 import com.example.repick.domain.clothingSales.entity.*;
-import com.example.repick.domain.clothingSales.repository.BagCollectRepository;
-import com.example.repick.domain.clothingSales.repository.BagCollectStateRepository;
-import com.example.repick.domain.clothingSales.repository.BagInitRepository;
-import com.example.repick.domain.clothingSales.repository.BagInitStateRepository;
+import com.example.repick.domain.clothingSales.repository.*;
 import com.example.repick.domain.clothingSales.validator.ClothingSalesValidator;
 import com.example.repick.domain.product.repository.ProductRepository;
 import com.example.repick.domain.user.entity.User;
@@ -33,14 +30,20 @@ public class BagService {
     private final ClothingSalesValidator clothingSalesValidator;
     private final S3UploadService s3UploadService;
     private final ProductRepository productRepository;
+    private final BoxCollectRepository boxCollectRepository;
 
     @Transactional
     public BagInitResponse registerBagInit(PostBagInit postBagInit) {
         User user = userRepository.findByProviderId(SecurityContextHolder.getContext().getAuthentication().getName())
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
 
+
+        // Count the number of the clothingSalesCount of the user
+        Integer bagInitCount = bagInitRepository.countByUserId(user.getId());
+        Integer boxCollectCount = boxCollectRepository.countByUserId(user.getId());
+
         // BagInit
-        BagInit bagInit = postBagInit.toEntity(user);
+        BagInit bagInit = postBagInit.toEntity(user, bagInitCount + boxCollectCount);
 
         bagInit.updateImageUrl(s3UploadService.saveFile(postBagInit.image(), "clothingSales/bagInit/" + user.getId() + "/" + bagInit.getId()));
 

--- a/src/main/java/com/example/repick/domain/clothingSales/service/BagService.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/service/BagService.java
@@ -87,7 +87,7 @@ public class BagService {
         clothingSalesValidator.duplicateBagCollectExists(bagInit.getId());
 
         // BagCollect
-        BagCollect bagCollect = postBagCollect.toEntity(bagInit);
+        BagCollect bagCollect = postBagCollect.toEntity(bagInit, user);
 
         bagCollect.updateImageUrl(s3UploadService.saveFile(postBagCollect.image(), "clothingSales/bagCollect/" + user.getId() + "/" + bagCollect.getId()));
 
@@ -114,23 +114,6 @@ public class BagService {
 
     public List<BagInit> getBagInitByUser(Long userId) {
         return bagInitRepository.findByUserId(userId);
-    }
-
-    public GetProductListByClothingSales getProductsByBagInitId(Long bagInitId) {
-        User user = userRepository.findByProviderId(SecurityContextHolder.getContext().getAuthentication().getName())
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
-
-        BagInit bagInit = bagInitRepository.findById(bagInitId)
-                .orElseThrow(() -> new CustomException(INVALID_BOX_COLLECT_ID));
-
-        // validate bagInitId and user
-        clothingSalesValidator.userBagInitMatches(user.getId(), bagInit);
-
-        List<GetProductByClothingSalesDto> getProductByClothingSalesDtoList = productRepository.findProductDtoByClothingSales(false, bagInitId);
-
-        Integer productQuantity = productRepository.countByIsBoxCollectAndClothingSalesId(false, bagInitId);
-
-        return new GetProductListByClothingSales(getProductByClothingSalesDtoList, bagInit.getBagQuantity(), productQuantity);
     }
 
     public BagInit getBagInitByBagInitId(Long bagInitId) {

--- a/src/main/java/com/example/repick/domain/clothingSales/service/BoxService.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/service/BoxService.java
@@ -77,23 +77,6 @@ public class BoxService {
         return boxCollectRepository.findByUserId(userId);
     }
 
-    public GetProductListByClothingSales getProductsByBoxId(Long boxCollectId) {
-        User user = userRepository.findByProviderId(SecurityContextHolder.getContext().getAuthentication().getName())
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
-
-        BoxCollect boxCollect = boxCollectRepository.findById(boxCollectId)
-                .orElseThrow(() -> new CustomException(INVALID_BOX_COLLECT_ID));
-
-        // validate boxCollectId and user
-        clothingSalesValidator.userBoxCollectMatches(user.getId(), boxCollect);
-
-        List<GetProductByClothingSalesDto> getProductByClothingSalesDtoList = productRepository.findProductDtoByClothingSales(true, boxCollectId);
-
-        Integer productQuantity = productRepository.countByIsBoxCollectAndClothingSalesId(true, boxCollectId);
-
-        return new GetProductListByClothingSales(getProductByClothingSalesDtoList, boxCollect.getBoxQuantity(), productQuantity);
-    }
-
     public BoxCollect getBoxCollectByBoxCollectId(Long boxCollectId) {
         return boxCollectRepository.findById(boxCollectId)
                 .orElseThrow(() -> new CustomException(INVALID_BOX_COLLECT_ID));

--- a/src/main/java/com/example/repick/domain/clothingSales/service/BoxService.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/service/BoxService.java
@@ -4,6 +4,7 @@ import com.example.repick.domain.clothingSales.dto.*;
 import com.example.repick.domain.clothingSales.entity.BoxCollect;
 import com.example.repick.domain.clothingSales.entity.BoxCollectState;
 import com.example.repick.domain.clothingSales.entity.BoxCollectStateType;
+import com.example.repick.domain.clothingSales.repository.BagInitRepository;
 import com.example.repick.domain.clothingSales.repository.BoxCollectRepository;
 import com.example.repick.domain.clothingSales.repository.BoxCollectStateRepository;
 import com.example.repick.domain.clothingSales.validator.ClothingSalesValidator;
@@ -31,6 +32,7 @@ public class BoxService {
     private final ProductRepository productRepository;
     private final S3UploadService s3UploadService;
     private final ClothingSalesValidator clothingSalesValidator;
+    private final BagInitRepository bagInitRepository;
 
 
     @Transactional
@@ -38,8 +40,13 @@ public class BoxService {
         User user = userRepository.findByProviderId(SecurityContextHolder.getContext().getAuthentication().getName())
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
+        // Count the number of the clothingSalesCount of the user
+        Integer bagInitCount = bagInitRepository.countByUserId(user.getId());
+        Integer boxCollectCount = boxCollectRepository.countByUserId(user.getId());
+
+
         // BoxCollect
-        BoxCollect boxCollect = postBoxCollect.toEntity(user);
+        BoxCollect boxCollect = postBoxCollect.toEntity(user, bagInitCount + boxCollectCount);
 
         boxCollect.updateImageUrl(s3UploadService.saveFile(postBoxCollect.image(), "clothingSales/boxCollect/" + user.getId() + "/" + boxCollect.getId()));
 

--- a/src/main/java/com/example/repick/domain/clothingSales/service/ClothingSalesService.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/service/ClothingSalesService.java
@@ -190,7 +190,7 @@ public class ClothingSalesService {
                     sellingQuantity.get(),
                     pendingQuantity.get(),
                     soldQuantity.get(),
-                    0));
+                    boxCollect.getPoint()));
         });
 
         bagInitList.forEach(bagInit -> {
@@ -220,7 +220,7 @@ public class ClothingSalesService {
                     sellingQuantity.get(),
                     pendingQuantity.get(),
                     soldQuantity.get(),
-                    0));
+                    bagInit.getPoint()));
         });
 
         return sellingClothingSalesList;

--- a/src/main/java/com/example/repick/domain/clothingSales/service/ClothingSalesService.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/service/ClothingSalesService.java
@@ -83,7 +83,7 @@ public class ClothingSalesService {
             });
 
             if (!isCanceledOrCompleted.get())
-                clothingSalesList.add(GetPendingClothingSales.of(bagInit.getId(), "백", requestDate.get(), bagArriveDate.get(), collectDate.get(), productDate.get()));
+                clothingSalesList.add(GetPendingClothingSales.of(bagInit.getId(), bagInit.getClothingSalesCount(), "백", requestDate.get(), bagArriveDate.get(), collectDate.get(), productDate.get()));
         });
 
 
@@ -109,7 +109,7 @@ public class ClothingSalesService {
             });
 
             if (!isCanceledOrCompleted.get())
-                clothingSalesList.add(GetPendingClothingSales.of(boxCollect.getId(), "박스", requestDate.get(), null, collectDate.get(), productDate.get()));
+                clothingSalesList.add(GetPendingClothingSales.of(boxCollect.getId(), boxCollect.getClothingSalesCount(), "박스", requestDate.get(), null, collectDate.get(), productDate.get()));
         });
 
         // order by created date
@@ -184,6 +184,7 @@ public class ClothingSalesService {
 
             sellingClothingSalesList.add(new GetSellingClothingSales(
                     boxCollect.getId(),
+                    boxCollect.getClothingSalesCount(),
                     true,
                     boxCollect.getCreatedDate().format(DateTimeFormatter.ofPattern("yy.MM.dd")),
                     sellingQuantity.get(),
@@ -213,6 +214,7 @@ public class ClothingSalesService {
 
             sellingClothingSalesList.add(new GetSellingClothingSales(
                     bagInit.getId(),
+                    bagInit.getClothingSalesCount(),
                     false,
                     bagInit.getCreatedDate().format(DateTimeFormatter.ofPattern("yy.MM.dd")),
                     sellingQuantity.get(),

--- a/src/main/java/com/example/repick/domain/product/dto/product/PostProduct.java
+++ b/src/main/java/com/example/repick/domain/product/dto/product/PostProduct.java
@@ -10,6 +10,7 @@ public record PostProduct (
         @Schema(description = "상품 카테고리") List<String> categories,
         @Schema(description = "상품 스타일") List<String> styles,
         @Schema(description = "판매하는 유저의 id", example = "5") Long userId,
+        @Schema(description = "수거 회차", example = "3") Integer clothingSalesCount,
         @Schema(description = "상품 코드", example = "17-1-1") String productCode,
         @Schema(description = "상품명", example = "블랙 카라 오버핏 셔츠") String productName,
         @Schema(description = "제안가", example = "40000") Long suggestedPrice,
@@ -21,14 +22,13 @@ public record PostProduct (
         @Schema(description = "치수 정보") Size sizeInfo,
         @Schema(description = "상품 품질 등급 (S, A, B)", example = "S") String qualityRate,
         @Schema(description = "상품 성별 (남성, 여성, 공용)", example = "남성") String gender,
-        @Schema(description = "박스 수거 여부, true: 박스 수거 false: 백 수거", example = "true") Boolean isBoxCollect,
-        @Schema(description = "수거 ID", example = "3") Long clothingSalesId,
         @Schema(description = "상품 소재 목록") List<String> materials
         ) {
 
     public Product toProduct(User user, String size) {
         return Product.builder()
                 .user(user)
+                .clothingSalesCount(this.clothingSalesCount())
                 .productCode(this.productCode())
                 .productName(this.productName())
                 .suggestedPrice(this.suggestedPrice())
@@ -40,8 +40,6 @@ public record PostProduct (
                 .sizeInfo(sizeInfo)
                 .qualityRate(QualityRate.fromValue(this.qualityRate()))
                 .gender(Gender.fromValue(this.gender()))
-                .isBoxCollect(this.isBoxCollect())
-                .clothingSalesId(this.clothingSalesId())
                 .build();
     }
 }

--- a/src/main/java/com/example/repick/domain/product/dto/product/ProductResponse.java
+++ b/src/main/java/com/example/repick/domain/product/dto/product/ProductResponse.java
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record ProductResponse(
         @Schema(description = "상품ID", example = "3") Long productId,
+        @Schema(description = "판매하는 유저의 id", example = "5") Long userId,
+        @Schema(description = "수거 회차", example = "3") Integer clothingSalesCount,
         @Schema(description = "상품명", example = "블랙 카라 오버핏 셔츠") String productName,
         @Schema(description = "제안가", example = "40000") Long suggestedPrice,
         @Schema(description = "상품 가격(할인 전)", example = "40000") Long price,
@@ -19,6 +21,8 @@ public record ProductResponse(
     public static ProductResponse fromProduct(Product product) {
         return new ProductResponse(
                 product.getId(),
+                product.getUser().getId(),
+                product.getClothingSalesCount(),
                 product.getProductName(),
                 product.getSuggestedPrice(),
                 product.getPrice(),

--- a/src/main/java/com/example/repick/domain/product/entity/Product.java
+++ b/src/main/java/com/example/repick/domain/product/entity/Product.java
@@ -17,6 +17,7 @@ public class Product extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
+    private Integer clothingSalesCount;
     private String productCode;
     private String productName;
     private Long price;
@@ -30,8 +31,6 @@ public class Product extends BaseEntity {
     private String size;
     @Embedded
     private Size sizeInfo;
-    private Boolean isBoxCollect;
-    private Long clothingSalesId;
     @Enumerated(EnumType.STRING)
     private QualityRate qualityRate;
     @Enumerated(EnumType.STRING)
@@ -51,6 +50,7 @@ public class Product extends BaseEntity {
     @Builder
     public Product(
             User user,
+            Integer clothingSalesCount,
             String productCode,
             String productName,
             Long price,
@@ -65,10 +65,9 @@ public class Product extends BaseEntity {
             Size sizeInfo,
             QualityRate qualityRate,
             String thumbnailImageUrl,
-            Gender gender,
-            Boolean isBoxCollect,
-            Long clothingSalesId) {
+            Gender gender) {
         this.user = user;
+        this.clothingSalesCount = clothingSalesCount;
         this.productCode = productCode;
         this.productName = productName;
         this.price = price;
@@ -84,8 +83,6 @@ public class Product extends BaseEntity {
         this.qualityRate = qualityRate;
         this.gender = gender;
         this.thumbnailImageUrl = thumbnailImageUrl;
-        this.isBoxCollect = isBoxCollect;
-        this.clothingSalesId = clothingSalesId;
     }
 
     public void updateUser(User user) {

--- a/src/main/java/com/example/repick/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/repick/domain/product/repository/ProductRepository.java
@@ -9,8 +9,8 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
-    List<Product> findProductByIsBoxCollectAndClothingSalesId(Boolean isBoxCollect, Long clothingSalesId);
-    Integer countByIsBoxCollectAndClothingSalesId(Boolean isBoxCollect, Long clothingSalesId);
+    List<Product> findProductByUserIdAndClothingSalesCount(Long userId, Integer clothingSalesCount);
+    Integer countByUserIdAndClothingSalesCount(Long userId, Integer clothingSalesCount);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT p FROM Product p WHERE p.id IN :ids")

--- a/src/main/java/com/example/repick/domain/product/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/example/repick/domain/product/repository/ProductRepositoryCustom.java
@@ -40,7 +40,7 @@ public interface ProductRepositoryCustom {
 
     Page<GetProductCart> findCartedProducts(Long userId, Pageable pageable);
 
-    List<GetProductByClothingSalesDto> findProductDtoByClothingSales(Boolean isBoxCollect, Long boxCollectId);
+    List<GetProductByClothingSalesDto> findProductDtoByUserIdAndClothingSalesCount(Long userId, Integer clothingSalesCount);
 
     List<Product> findByProductSellingStateType(ProductStateType productStateType);
 

--- a/src/main/java/com/example/repick/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/example/repick/domain/product/repository/ProductRepositoryImpl.java
@@ -301,7 +301,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
     }
 
     @Override
-    public List<GetProductByClothingSalesDto> findProductDtoByClothingSales(Boolean isBoxCollect, Long clothingSalesId) {
+    public List<GetProductByClothingSalesDto> findProductDtoByUserIdAndClothingSalesCount(Long userId, Integer clothingSalesCount) {
         return jpaQueryFactory
                 .select(Projections.constructor(GetProductByClothingSalesDto.class,
                         product.id,
@@ -315,8 +315,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                         product.predictPriceDiscountRate))
                 .from(product)
                 .leftJoin(productState).on(product.id.eq(productState.productId))
-                .where(product.isBoxCollect.eq(isBoxCollect)
-                        .and(product.clothingSalesId.eq(clothingSalesId))
+                .where(product.clothingSalesCount.eq(clothingSalesCount)
                         .and(product.isDeleted.isFalse())
                         .and(JPAExpressions
                                 .select(productState.id.max())

--- a/src/main/java/com/example/repick/domain/product/service/ProductService.java
+++ b/src/main/java/com/example/repick/domain/product/service/ProductService.java
@@ -92,7 +92,7 @@ public class ProductService {
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         // validate clothing sales info
-        productValidator.validateClothingSales(postProduct.isBoxCollect(), postProduct.clothingSalesId(), user.getId());
+        productValidator.validateClothingSales(postProduct.clothingSalesCount(), user.getId());
 
         // product
         String size  = convertSizeInfo(Category.fromName(postProduct.categories().get(0)), postProduct.sizeInfo());
@@ -389,8 +389,8 @@ public class ProductService {
         productRepository.save(product);
     }
 
-    public List<Product> findByClothingSales(Boolean isBoxCollect, Long clothingSlaesId) {
-        return productRepository.findProductByIsBoxCollectAndClothingSalesId(isBoxCollect, clothingSlaesId);
+    public List<Product> findByClothingSales(Long userId, Integer clothingSalesCount) {
+        return productRepository.findProductByUserIdAndClothingSalesCount(userId, clothingSalesCount);
     }
 
     public List<GetClassificationEach> getProductStyleTypes() {

--- a/src/main/java/com/example/repick/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/example/repick/global/error/exception/ErrorCode.java
@@ -57,6 +57,8 @@ public enum ErrorCode {
     // BoxCollectStateType
     INVALID_BOX_COLLECT_STATUS_ID(400, "B501", "존재하지 않는 박스 수거 상태 ID입니다."),
     INVALID_BOX_COLLECT_STATUS_NAME(400, "B502", "존재하지 않는 박스 수거 상태 이름입니다."),
+    // ClothingSales
+    INVALID_CLOTHING_SALES(400, "B601", "존재하지 않는 수거 요청입니다."),
     // ProductSellingState
     INVALID_SELLING_STATE_ID(400, "P031", "존재하지 않는 판매 상태 ID입니다."),
     INVALID_SELLING_STATE_NAME(400, "P042", "존재하지 않는 판매 상태 이름입니다."),


### PR DESCRIPTION
1. 각각의 옷장 정리에 totalPrice 필드를 추가합니다. 

각각의 옷장 정리에 대한 정산금을 저장하는 필드 totalPrice 를 추가합니다.

2. 유저의 옷장 정리 회차를 구분짓는 clothingSalesCount 칼럼을 추가합니다.

Product 엔티티의 필드가 변경됩니다:

[기존]
isBoxCollect: 백/박스 여부
clothingSalesId: 옷장 수거 ID

[변경 후]
clothingSalesCount: 회차

clothingSalesCount는 userId에 대해 unique 하기 때문에 다음의 수정 과정을 거쳤습니다.

