### PR TITLE
Fix: rejected product metadata

### DIFF
--- a/src/main/java/com/example/repick/domain/product/dto/product/PostProduct.java
+++ b/src/main/java/com/example/repick/domain/product/dto/product/PostProduct.java
@@ -33,6 +33,8 @@ public record PostProduct (
                 .clothingSales(clothingSales)
                 .clothingSalesCount(this.clothingSalesCount())
                 .productCode(this.productCode())
+                .productName(this.productName())
+                .brandName(this.brandName())
                 .productState(ProductStateType.REJECTED)
                 .build();
     }

--- a/src/main/java/com/example/repick/domain/product/service/ProductService.java
+++ b/src/main/java/com/example/repick/domain/product/service/ProductService.java
@@ -126,22 +126,18 @@ public class ProductService {
     }
 
     private Product handleRejectedProduct(PostProduct postProduct, User user, List<MultipartFile> images) {
-        System.out.println("ProductService.handleRejectedProduct");
         ClothingSales clothingSales = clothingSalesRepository.findByUserAndClothingSalesCount(user, postProduct.clothingSalesCount())
                 .orElseThrow(() -> new CustomException(CLOTHING_SALES_NOT_FOUND));
         // product
         Product product = productRepository.save(postProduct.toRejectedProduct(user, clothingSales));
 
-        System.out.println("ProductService.handleRejectedProduct2");
         // productImage
         String thumbnailGeneratedUrl = uploadImage(images, product);
         product.updateThumbnailImageUrl(thumbnailGeneratedUrl);
 
-        System.out.println("ProductService.handleRejectedProduct3");
         // productSellingState
         addProductSellingState(product.getId(), ProductStateType.REJECTED);
 
-        System.out.println("ProductService.handleRejectedProduct4");
         return product;
 
     }

--- a/src/main/java/com/example/repick/domain/product/service/ProductService.java
+++ b/src/main/java/com/example/repick/domain/product/service/ProductService.java
@@ -403,10 +403,6 @@ public class ProductService {
         productRepository.save(product);
     }
 
-    public List<Product> findByClothingSales(Long userId, Integer clothingSalesCount) {
-        return productRepository.findProductByUserIdAndClothingSalesCount(userId, clothingSalesCount);
-    }
-
     public List<GetClassificationEach> getProductStyleTypes() {
         List<GetClassificationEach> types = new ArrayList<>();
 


### PR DESCRIPTION
Closes #121  .

# [Fix] 가격 설정 페이지 api rejected 상품 상품명, 브랜드 등 메타데이터 입력

### 📝 Description


1. 람다 함수 수정 

``` python
            if pd.notnull(row['is_rejected']):
                # Process rejected products
                post_product = {
                    "userId": row['user_id'],
                    "clothingSalesCount": row['clothing_sales_count'],
                    "productCode": product_code,
                    "productName": row['product_name'], # 추가됨
                    "brandName": row['brand_name'], # 추가됨 
                    "isRejected": "true"
                }
```

2. PostProduct.java: toRejectedProduct 수정

``` java
    public Product toRejectedProduct(User user, ClothingSales clothingSales) {
        return Product.builder()
                .user(user)
                .clothingSales(clothingSales)
                .clothingSalesCount(this.clothingSalesCount())
                .productCode(this.productCode())
                .productName(this.productName()) # 추가됨
                .brandName(this.brandName()) # 추가됨
                .productState(ProductStateType.REJECTED)
                .build();
    }
```
