### PR TITLE
fix: getClothingSales api

### DIFF
--- a/src/main/java/com/example/repick/domain/clothingSales/entity/ClothingSales.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/entity/ClothingSales.java
@@ -55,6 +55,7 @@ public abstract class ClothingSales {
     @Column(name = "collection_date")
     private LocalDate collectionDate;
 
+    @Enumerated(EnumType.STRING)
     private ClothingSalesStateType clothingSalesState;
 
     @OneToMany(mappedBy = "clothingSales")

--- a/src/main/java/com/example/repick/domain/clothingSales/entity/ClothingSalesStateType.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/entity/ClothingSalesStateType.java
@@ -29,6 +29,7 @@ public enum ClothingSalesStateType {
     private final String sellerValue;
     private final String adminValue;
 
+    public static final List<ClothingSalesStateType> BEFORE_COLLECTION = Arrays.asList(BAG_INIT_REQUEST, REQUEST_CANCELLED, BAG_DELIVERY, BAG_DELIVERED);
     public static final List<ClothingSalesStateType> AFTER_PRODUCTION = Arrays.asList(PRODUCT_REGISTERED, SELLING, SELLING_EXPIRED);
     public static final List<ClothingSalesStateType> AFTER_SELLING = Arrays.asList(SELLING, SELLING_EXPIRED);
 

--- a/src/main/java/com/example/repick/domain/clothingSales/repository/ClothingSalesRepository.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/repository/ClothingSalesRepository.java
@@ -3,12 +3,15 @@ package com.example.repick.domain.clothingSales.repository;
 import com.example.repick.domain.clothingSales.entity.ClothingSales;
 import com.example.repick.domain.clothingSales.entity.ClothingSalesStateType;
 import com.example.repick.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface ClothingSalesRepository extends JpaRepository<ClothingSales, Long> {
+    Page<ClothingSales> findAllByOrderByCreatedDateDesc(Pageable pageable);
     List<ClothingSales> findByUserAndClothingSalesState(User user, ClothingSalesStateType clothingSalesStateType);
     List<ClothingSales> findByUserOrderByCreatedDateDesc(User user);
     Optional<ClothingSales> findByUserAndClothingSalesCount(User user, Integer clothingSalesCount);

--- a/src/main/java/com/example/repick/domain/clothingSales/service/BagService.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/service/BagService.java
@@ -65,10 +65,9 @@ public class BagService {
         // BagCollect
         bagCollect.updateBagCollectInfo(postBagCollect.bagQuantity(), postBagCollect.postalCode(), postBagCollect.mainAddress(), postBagCollect.detailAddress(), postBagCollect.collectionDate());
         bagCollect.updateImageUrl(s3UploadService.saveFile(postBagCollect.image(), "clothingSales/bagCollect/" + user.getId() + "/" + bagCollect.getId()));
-        bagCollectRepository.save(bagCollect);
-
-        // BagCollectState
         ClothingSalesState clothingSalesState = ClothingSalesState.of(bagCollect.getId(), ClothingSalesStateType.BAG_COLLECT_REQUEST);
+        bagCollect.updateClothingSalesState(ClothingSalesStateType.BAG_COLLECT_REQUEST);
+        bagCollectRepository.save(bagCollect);
         clothingSalesStateRepository.save(clothingSalesState);
 
         return BagCollectResponse.of(bagCollect, clothingSalesState.getClothingSalesStateType().getSellerValue());


### PR DESCRIPTION
# 옷장 정리 현황 api 수정

- 리픽백 요청일 경우 리픽백 배송~판매완료까지 하나의 항목으로
- api 리팩토링
- 리픽백 수거 요청시 ClothingSales의 clothing_sales_state 필드 업데이트
- ClothingSales의 clothing_sales_state 필드에 `@Enumerated(EnumType.STRING)` 추가
   -  DB에 다음 구문 실행:
   `ALTER TABLE clothing_sales  MODIFY clothing_sales_state VARCHAR(255);` 