### PR TITLE
feat: sorting latest oldest 

### DIFF
--- a/src/main/java/com/example/repick/domain/clothingSales/api/ClothingSalesController.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/api/ClothingSalesController.java
@@ -9,6 +9,7 @@ import com.example.repick.global.page.PageCondition;
 import com.example.repick.global.page.PageResponse;
 import com.example.repick.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.MediaType;
@@ -105,8 +106,10 @@ public class ClothingSalesController {
 
     @Operation(summary = "옷장 정리 현황")
     @GetMapping("/status")
-    public SuccessResponse<PageResponse<List<GetClothingSales>>> getClothingSalesStatus(@ParameterObject  PageCondition pageCondition, @ParameterObject DateCondition dateCondition) {
-        return SuccessResponse.success(clothingSalesService.getClothingSalesInformation(pageCondition, dateCondition));
+    public SuccessResponse<PageResponse<List<GetClothingSales>>> getClothingSalesStatus(@Parameter(description = "조회 타입 (latest, oldest)") @RequestParam(value = "type", defaultValue = "latest", required = false) String type,
+                                                                                        @ParameterObject  PageCondition pageCondition,
+                                                                                        @ParameterObject DateCondition dateCondition) {
+        return SuccessResponse.success(clothingSalesService.getClothingSalesInformation(type, pageCondition, dateCondition));
     }
 
     @Operation(summary = "옷장 정리 상태 업데이트")

--- a/src/main/java/com/example/repick/domain/clothingSales/repository/ClothingSalesRepository.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/repository/ClothingSalesRepository.java
@@ -14,9 +14,11 @@ import java.util.Optional;
 
 public interface ClothingSalesRepository extends JpaRepository<ClothingSales, Long> {
     Page<ClothingSales> findAllByOrderByCreatedDateDesc(Pageable pageable);
+    Page<ClothingSales> findAllByOrderByCreatedDateAsc(Pageable pageable);
     List<ClothingSales> findByClothingSalesState(ClothingSalesStateType clothingSalesStateType);
     List<ClothingSales> findByUserAndClothingSalesState(User user, ClothingSalesStateType clothingSalesStateType);
     Page<ClothingSales> findByCreatedDateBetweenOrderByCreatedDateDesc(LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
+    Page<ClothingSales> findByCreatedDateBetweenOrderByCreatedDateAsc(LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
     List<ClothingSales> findByUserOrderByCreatedDateDesc(User user);
     Optional<ClothingSales> findByUserAndClothingSalesCount(User user, Integer clothingSalesCount);
     int countByUser(User user);

--- a/src/main/java/com/example/repick/domain/clothingSales/service/ClothingSalesService.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/service/ClothingSalesService.java
@@ -31,6 +31,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.example.repick.global.error.exception.ErrorCode.*;
@@ -178,13 +179,14 @@ public class ClothingSalesService {
     }
 
     private Page<ClothingSales> getClothingSalesByType(String type, PageCondition pageCondition, DateCondition dateCondition) {
-        LocalDateTime startDateTime = null;
-        LocalDateTime endDateTime = null;
+        LocalDateTime startDateTime = Optional.ofNullable(dateCondition.startDate())
+                .map(LocalDate::atStartOfDay)
+                .orElse(null);
 
-        if (dateCondition.hasValidDateRange()) {
-            startDateTime = dateCondition.startDate().atStartOfDay();
-            endDateTime = dateCondition.endDate().atTime(LocalTime.MAX);
-        }
+        LocalDateTime endDateTime = Optional.ofNullable(dateCondition.endDate())
+                .map(date -> date.atTime(LocalTime.MAX))
+                .orElse(null);
+
         if ("oldest".equals(type)) {
             if (dateCondition.hasValidDateRange()) {
                 return clothingSalesRepository.findByCreatedDateBetweenOrderByCreatedDateAsc(startDateTime, endDateTime, pageCondition.toPageable());

--- a/src/main/java/com/example/repick/domain/clothingSales/service/ClothingSalesService.java
+++ b/src/main/java/com/example/repick/domain/clothingSales/service/ClothingSalesService.java
@@ -187,20 +187,22 @@ public class ClothingSalesService {
                 .map(date -> date.atTime(LocalTime.MAX))
                 .orElse(null);
 
-        if ("oldest".equals(type)) {
-            if (dateCondition.hasValidDateRange()) {
-                return clothingSalesRepository.findByCreatedDateBetweenOrderByCreatedDateAsc(startDateTime, endDateTime, pageCondition.toPageable());
-            } else {
-                return clothingSalesRepository.findAllByOrderByCreatedDateAsc(pageCondition.toPageable());
+        switch (type) {
+            case "oldest" -> {
+                if (dateCondition.hasValidDateRange()) {
+                    return clothingSalesRepository.findByCreatedDateBetweenOrderByCreatedDateAsc(startDateTime, endDateTime, pageCondition.toPageable());
+                } else {
+                    return clothingSalesRepository.findAllByOrderByCreatedDateAsc(pageCondition.toPageable());
+                }
             }
-        } else if ("latest".equals(type)) {
-            if (dateCondition.hasValidDateRange()) {
-                return clothingSalesRepository.findByCreatedDateBetweenOrderByCreatedDateDesc(startDateTime, endDateTime, pageCondition.toPageable());
-            } else {
-                return clothingSalesRepository.findAllByOrderByCreatedDateDesc(pageCondition.toPageable());
+            case "latest" -> {
+                if (dateCondition.hasValidDateRange()) {
+                    return clothingSalesRepository.findByCreatedDateBetweenOrderByCreatedDateDesc(startDateTime, endDateTime, pageCondition.toPageable());
+                } else {
+                    return clothingSalesRepository.findAllByOrderByCreatedDateDesc(pageCondition.toPageable());
+                }
             }
-        } else {
-            throw new CustomException(INVALID_SORT_TYPE);
+            default -> throw new CustomException(INVALID_SORT_TYPE);
         }
     }
 

--- a/src/main/java/com/example/repick/domain/product/api/ProductController.java
+++ b/src/main/java/com/example/repick/domain/product/api/ProductController.java
@@ -235,9 +235,10 @@ public class ProductController {
 
     @Operation(summary = "상품 종합 현황")
     @GetMapping("/count")
-    public SuccessResponse<PageResponse<List<GetProductCountClothingSales>>> getProductCountByClothingSales(@RequestParam(required = false) Long userId,
+    public SuccessResponse<PageResponse<List<GetProductCountClothingSales>>> getProductCountByClothingSales(@Parameter(description = "조회 타입 (latest, oldest)") @RequestParam(value = "type", defaultValue = "latest", required = false) String type,
+                                                                                                            @RequestParam(required = false) Long userId,
                                                                                                             @ParameterObject PageCondition pageCondition) {
-        return SuccessResponse.success(productService.getProductCountByClothingSales(userId, pageCondition));
+        return SuccessResponse.success(productService.getProductCountByClothingSales(type, userId, pageCondition));
     }
 
     @Operation(summary = "유저 상품 현황",

--- a/src/main/java/com/example/repick/domain/product/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/example/repick/domain/product/repository/ProductRepositoryCustom.java
@@ -50,7 +50,7 @@ public interface ProductRepositoryCustom {
 
     List<Product> findRecommendation(Long userId);
 
-    Page<GetProductCountClothingSales> getClothingSalesProductCount(Pageable pageable, Long userId);
+    Page<GetProductCountClothingSales> getClothingSalesProductCount(String type, Pageable pageable, Long userId);
 
     Page<GetProductsClothingSales> getClothingSalesProduct(Long clothingSalesId, ProductStateType productStateType, Pageable pageable);
 

--- a/src/main/java/com/example/repick/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/example/repick/domain/product/repository/ProductRepositoryImpl.java
@@ -378,7 +378,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
     }
 
     @Override
-    public Page<GetProductCountClothingSales> getClothingSalesProductCount(Pageable pageable, Long userId) {
+    public Page<GetProductCountClothingSales> getClothingSalesProductCount(String type, Pageable pageable, Long userId) {
         JPAQuery<GetProductCountClothingSales> query =  jpaQueryFactory
                 .select(Projections.constructor(GetProductCountClothingSales.class,
                         product.user.id.stringValue().concat("-").concat(product.clothingSalesCount.stringValue()),
@@ -397,9 +397,13 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                 .leftJoin(clothingSales).on(product.clothingSales.id.eq(clothingSales.id))
                 .groupBy(
                         product.clothingSales.id
-                )
+                );
 
-                .orderBy(clothingSales.createdDate.max().desc());
+        if ("latest".equalsIgnoreCase(type)) {
+            query.orderBy(clothingSales.createdDate.max().desc());
+        } else if ("oldest".equalsIgnoreCase(type)) {
+            query.orderBy(clothingSales.createdDate.max().asc());
+        }
 
         if (userId != null) {
             query.where(product.user.id.eq(userId));

--- a/src/main/java/com/example/repick/domain/product/service/ProductService.java
+++ b/src/main/java/com/example/repick/domain/product/service/ProductService.java
@@ -481,8 +481,8 @@ public class ProductService {
     }
 
     @Transactional
-    public PageResponse<List<GetProductCountClothingSales>> getProductCountByClothingSales(Long userId, PageCondition pageCondition) {
-        Page<GetProductCountClothingSales> pages = productRepository.getClothingSalesProductCount(pageCondition.toPageable(), userId);
+    public PageResponse<List<GetProductCountClothingSales>> getProductCountByClothingSales(String type, Long userId, PageCondition pageCondition) {
+        Page<GetProductCountClothingSales> pages = productRepository.getClothingSalesProductCount(type, pageCondition.toPageable(), userId);
         return PageResponse.of(pages.getContent(), pages.getTotalPages(), pages.getTotalElements());
     }
 


### PR DESCRIPTION
[Feature] 최신순/오래된순 정렬 기능 추가
---
상품 종합 현황과 옷장 정리 현황 페이지에서 오래된순, 최신순 정렬 기능을 추가합니다.

옷장 정리 현황 정렬 기능 추가
---
기존 상품 조회 페이지에 조회 타입 기능을 참고하여 정렬 기능을 추가했습니다. (디폴트는 최신순으로 정렬했습니다)

_(중복되는 코드가 많아 수정 한 번 했습니다)_

getClothingSales라는 메소드명이 너무 마음에 안 드는데 혹시 추천해주신다면 즉시 변경하도록 하겠습니다. 

<img width="475" alt="image" src="https://github.com/user-attachments/assets/e518fc74-b53c-47d2-b55f-5a71495959ec">


상품 종합 현황 정렬 기능 추가
---
getClothingSalesProductCountImpl 메소드 내부에  신청일 오름차순 정렬을 추가해주었습니다. 

<img width="475" alt="image" src="https://github.com/user-attachments/assets/bff79753-f186-4795-8436-2d963130138f">
