### PR TITLE
fix: add gender to social login

### DIFF
--- a/src/main/java/com/example/repick/domain/user/dto/GoogleUserDto.java
+++ b/src/main/java/com/example/repick/domain/user/dto/GoogleUserDto.java
@@ -11,21 +11,24 @@ public class GoogleUserDto {
     private String email;
     private String nickname;
     private String profileImage;
+    private String gender;
 
     @Builder
-    public GoogleUserDto(String id, String email, String nickname, String profileImage) {
+    public GoogleUserDto(String id, String email, String nickname, String profileImage, String gender) {
         this.id = id;
         this.email = email;
         this.nickname = nickname;
         this.profileImage = profileImage;
+        this.gender = gender;
     }
 
-    public static GoogleUserDto of(String id, String email, String nickname, String profileImage) {
+    public static GoogleUserDto of(String id, String email, String nickname, String profileImage, String gender) {
         return GoogleUserDto.builder()
                 .id(id)
                 .email(email)
                 .nickname(nickname)
                 .profileImage(profileImage)
+                .gender(gender)
                 .build();
     }
 }

--- a/src/main/java/com/example/repick/domain/user/dto/KakaoUserDto.java
+++ b/src/main/java/com/example/repick/domain/user/dto/KakaoUserDto.java
@@ -11,21 +11,24 @@ public class KakaoUserDto {
     private String email;
     private String nickname;
     private String profileImage;
+    private String gender;
 
     @Builder
-    public KakaoUserDto(String id, String email, String nickname, String profileImage) {
+    public KakaoUserDto(String id, String email, String nickname, String profileImage, String gender) {
         this.id = id;
         this.email = email;
         this.nickname = nickname;
         this.profileImage = profileImage;
+        this.gender = gender;
     }
 
-    public static KakaoUserDto of(String id, String email, String nickname, String profileImage) {
+    public static KakaoUserDto of(String id, String email, String nickname, String profileImage, String gender) {
         return KakaoUserDto.builder()
                 .id(id)
                 .email(email)
                 .nickname(nickname)
                 .profileImage(profileImage)
+                .gender(gender)
                 .build();
     }
 }

--- a/src/main/java/com/example/repick/domain/user/dto/NaverUserDto.java
+++ b/src/main/java/com/example/repick/domain/user/dto/NaverUserDto.java
@@ -12,6 +12,7 @@ public class NaverUserDto {
     private String nickname;
     private String profileImage;
     private String phoneNumber;
+    private String gender;
 
     @JsonProperty("response")
     private void unpackNested(Response response) {
@@ -20,6 +21,7 @@ public class NaverUserDto {
         this.nickname = response.nickname;
         this.profileImage = response.profile_image;
         this.phoneNumber = response.phoneNumber;
+        this.gender = response.gender;
     }
 
     private static class Response {
@@ -28,6 +30,7 @@ public class NaverUserDto {
         public String nickname;
         public String profile_image;
         public String phoneNumber;
+        public String gender;
     }
 }
 

--- a/src/main/java/com/example/repick/domain/user/entity/Gender.java
+++ b/src/main/java/com/example/repick/domain/user/entity/Gender.java
@@ -1,5 +1,33 @@
 package com.example.repick.domain.user.entity;
 
 public enum Gender {
-    MALE, FEMALE
+    MALE, FEMALE;
+
+    public static Gender fromNaverInfo(String naverGender) {
+        switch (naverGender) {
+            case "M":
+                return MALE;
+            case "F":
+                return FEMALE;
+    }
+        return null;
+    }
+    public static Gender fromKakaoInfo(String kakaoGender) {
+        switch (kakaoGender) {
+            case "male":
+                return MALE;
+            case "female":
+                return FEMALE;
+        }
+        return null;
+    }
+    public static Gender fromGoogleInfo(String googleGender) {
+        switch (googleGender) {
+            case "male":
+                return MALE;
+            case "female":
+                return FEMALE;
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/example/repick/domain/user/entity/Gender.java
+++ b/src/main/java/com/example/repick/domain/user/entity/Gender.java
@@ -4,30 +4,45 @@ public enum Gender {
     MALE, FEMALE;
 
     public static Gender fromNaverInfo(String naverGender) {
+        if (naverGender == null) {
+            return null;
+        }
+
         switch (naverGender) {
             case "M":
                 return MALE;
             case "F":
                 return FEMALE;
-    }
-        return null;
+            default:
+                return null;
+        }
     }
     public static Gender fromKakaoInfo(String kakaoGender) {
+        if (kakaoGender == null) {
+            return null;
+        }
+
         switch (kakaoGender) {
             case "male":
                 return MALE;
             case "female":
                 return FEMALE;
+            default:
+                return null;
         }
-        return null;
     }
+
     public static Gender fromGoogleInfo(String googleGender) {
+        if (googleGender == null) {
+            return null;
+        }
         switch (googleGender) {
             case "male":
                 return MALE;
             case "female":
                 return FEMALE;
+            default:
+                return null;
         }
-        return null;
     }
 }

--- a/src/main/java/com/example/repick/domain/user/entity/User.java
+++ b/src/main/java/com/example/repick/domain/user/entity/User.java
@@ -56,7 +56,7 @@ public class User extends BaseEntity {
     private Role role;
 
     @Builder
-    public User(Long id, OAuthProvider oAuthProvider, String providerId, String email, String nickname, String phoneNumber, Address defaultAddress, Account defaultAccount, String topSize, String bottomSize, String profileImage, String password, Role role, Boolean pushAllow, String fcmToken) {
+    public User(Long id, OAuthProvider oAuthProvider, String providerId, String email, String nickname, String phoneNumber, Address defaultAddress, Account defaultAccount, String topSize, String bottomSize, String profileImage, String password, Role role, Boolean pushAllow, String fcmToken, Gender gender ) {
         this.id = id;
         this.oAuthProvider = oAuthProvider;
         this.providerId = providerId;
@@ -74,6 +74,7 @@ public class User extends BaseEntity {
         this.pushAllow = pushAllow;
         this.fcmToken = fcmToken;
         this.userClass = UserClass.ROOKIE_COLLECTOR;
+        this.gender = gender;
     }
 
 

--- a/src/main/java/com/example/repick/global/oauth/GoogleUserService.java
+++ b/src/main/java/com/example/repick/global/oauth/GoogleUserService.java
@@ -2,6 +2,7 @@ package com.example.repick.global.oauth;
 
 import com.example.repick.domain.recommendation.service.RecommendationService;
 import com.example.repick.domain.user.dto.GoogleUserDto;
+import com.example.repick.domain.user.entity.Gender;
 import com.example.repick.domain.user.entity.OAuthProvider;
 import com.example.repick.domain.user.entity.Role;
 import com.example.repick.domain.user.entity.User;
@@ -48,16 +49,42 @@ public class GoogleUserService {
 
     private GoogleUserDto getGoogleUserInfo(String accessToken) throws JsonProcessingException {
         HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization","Bearer "+ accessToken);
-        HttpEntity<MultiValueMap<String, String>> googleUserInfoRequest = new HttpEntity<>(headers);
+        headers.add("Authorization", "Bearer " + accessToken);
         RestTemplate restTemplate = new RestTemplate();
+
+        // 첫 번째 요청: 기본 사용자 정보 가져오기
+        HttpEntity<MultiValueMap<String, String>> googleUserInfoRequest = new HttpEntity<>(headers);
         ResponseEntity<String> response = restTemplate.exchange(
                 "https://www.googleapis.com/oauth2/v1/userinfo",
                 HttpMethod.GET,
                 googleUserInfoRequest,
                 String.class
         );
-        return handleGoogleResponse(response.getBody());
+        GoogleUserDto userInfo = handleGoogleResponse(response.getBody());
+
+        // 두 번째 요청: 성별 정보 가져오기
+        HttpEntity<MultiValueMap<String, String>> genderInfoRequest = new HttpEntity<>(headers);
+        ResponseEntity<String> genderResponse = restTemplate.exchange(
+                "https://people.googleapis.com/v1/people/me?personFields=genders",
+                HttpMethod.GET,
+                genderInfoRequest,
+                String.class
+        );
+
+        // JSON 파싱하여 성별 정보 추출
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode genderNode = objectMapper.readTree(genderResponse.getBody())
+                .path("genders")
+                .path(0)
+                .path("value");
+
+        String genderValue = null;
+        if (!genderNode.isMissingNode()) {
+            genderValue = genderNode.asText();
+        }
+
+        // GoogleUserDto에 성별 정보 포함시켜 리턴
+        return GoogleUserDto.of(userInfo.getId(), userInfo.getEmail(), userInfo.getNickname(), userInfo.getProfileImage(), genderValue);
     }
 
 
@@ -75,6 +102,7 @@ public class GoogleUserService {
                     .profileImage(googleUserInfo.getProfileImage())
                     .password(password)
                     .pushAllow(false)
+                    .gender(Gender.fromGoogleInfo(googleUserInfo.getGender()))
                     .build();
             userRepository.save(googleUser);
 
@@ -99,6 +127,6 @@ public class GoogleUserService {
 
         String profileImage = jsonNode.get("picture").asText();
 
-        return GoogleUserDto.of(id, email, nickname, profileImage);
+        return GoogleUserDto.of(id, email, nickname, profileImage, null);
     }
 }

--- a/src/main/java/com/example/repick/global/oauth/GoogleUserService.java
+++ b/src/main/java/com/example/repick/global/oauth/GoogleUserService.java
@@ -1,5 +1,6 @@
 package com.example.repick.global.oauth;
 
+import com.example.repick.domain.recommendation.service.RecommendationService;
 import com.example.repick.domain.user.dto.GoogleUserDto;
 import com.example.repick.domain.user.entity.OAuthProvider;
 import com.example.repick.domain.user.entity.Role;
@@ -30,6 +31,7 @@ import java.util.UUID;
 public class GoogleUserService {
     private final UserRepository userRepository;
     private final SecurityService securityService;
+    private final RecommendationService recommendationService;
 
     @Value("${oauth.google.client-id}")
     private String clientId;
@@ -75,6 +77,10 @@ public class GoogleUserService {
                     .pushAllow(false)
                     .build();
             userRepository.save(googleUser);
+
+            // create user preference
+            recommendationService.registerUserPreference(googleUser.getId());
+
             return Pair.of(googleUser, true);
         }
         return Pair.of(googleUser, false);

--- a/src/main/java/com/example/repick/global/oauth/KakaoUserService.java
+++ b/src/main/java/com/example/repick/global/oauth/KakaoUserService.java
@@ -2,6 +2,7 @@ package com.example.repick.global.oauth;
 
 import com.example.repick.domain.recommendation.service.RecommendationService;
 import com.example.repick.domain.user.dto.KakaoUserDto;
+import com.example.repick.domain.user.entity.Gender;
 import com.example.repick.domain.user.entity.OAuthProvider;
 import com.example.repick.domain.user.entity.Role;
 import com.example.repick.domain.user.entity.User;
@@ -82,7 +83,9 @@ public class KakaoUserService {
 
         String thumbnailImage = jsonNode.get("kakao_account").get("profile").get("thumbnail_image_url").asText();
 
-        return KakaoUserDto.of(id, email, nickname, thumbnailImage);
+        String gender = jsonNode.get("kakao_account").get("gender").asText();
+
+        return KakaoUserDto.of(id, email, nickname, thumbnailImage, gender);
     }
 
     private Pair<User, Boolean> registerKakaoUserIfNeed (KakaoUserDto kakaoUserInfo) {
@@ -104,6 +107,7 @@ public class KakaoUserService {
                     .role(Role.USER)
                     .password(password)
                     .pushAllow(false)
+                    .gender(Gender.fromKakaoInfo(kakaoUserInfo.getGender()))
                     .build();
 
             userRepository.save(kakaoUser);

--- a/src/main/java/com/example/repick/global/oauth/KakaoUserService.java
+++ b/src/main/java/com/example/repick/global/oauth/KakaoUserService.java
@@ -83,7 +83,8 @@ public class KakaoUserService {
 
         String thumbnailImage = jsonNode.get("kakao_account").get("profile").get("thumbnail_image_url").asText();
 
-        String gender = jsonNode.get("kakao_account").get("gender").asText();
+        JsonNode genderNode = jsonNode.get("kakao_account").get("gender");
+        String gender = (genderNode != null) ? genderNode.asText(null) : null;
 
         return KakaoUserDto.of(id, email, nickname, thumbnailImage, gender);
     }

--- a/src/main/java/com/example/repick/global/oauth/NaverUserService.java
+++ b/src/main/java/com/example/repick/global/oauth/NaverUserService.java
@@ -78,10 +78,10 @@ public class NaverUserService {
                     .pushAllow(false)
                     .build();
 
+            userRepository.save(naverUser);
             // create user preference
             recommendationService.registerUserPreference(naverUser.getId());
 
-            userRepository.save(naverUser);
             return Pair.of(naverUser, true);
         }
         return Pair.of(naverUser, false);

--- a/src/main/java/com/example/repick/global/oauth/NaverUserService.java
+++ b/src/main/java/com/example/repick/global/oauth/NaverUserService.java
@@ -2,6 +2,7 @@ package com.example.repick.global.oauth;
 
 import com.example.repick.domain.recommendation.service.RecommendationService;
 import com.example.repick.domain.user.dto.NaverUserDto;
+import com.example.repick.domain.user.entity.Gender;
 import com.example.repick.domain.user.entity.OAuthProvider;
 import com.example.repick.domain.user.entity.Role;
 import com.example.repick.domain.user.entity.User;
@@ -74,6 +75,7 @@ public class NaverUserService {
                     .profileImage(naverUserInfo.getProfileImage())
                     .phoneNumber(naverUserInfo.getPhoneNumber())
                     .role(Role.USER)
+                    .gender(Gender.fromNaverInfo(naverUserInfo.getGender()))
                     .password(password)
                     .pushAllow(false)
                     .build();


### PR DESCRIPTION
[Fix] 성별 정보 추가 저장
---

- 성별을 제공 받지 않는 애플을 제외한 구글, 네이버, 카카오에서 성별을 추가적으로 제공 받아 저장합니다. 
- 구글은 더 이상 userInfo에서 성별과 생일 정보를 제공하지 않아, 추가적으로 공개 API를 사용하여 성별 정보를 추출했습니다. 
<img width="258" alt="image" src="https://github.com/user-attachments/assets/b1469d99-3b19-401e-a897-329bb3b56dea">
<img width="293" alt="image" src="https://github.com/user-attachments/assets/9fcc5fc0-85aa-4384-ab88-3f0f7eac296a">

각각 네이버, 카카오, 구글 유저에 성별이 잘 들어가 있는 것을 확인 할 수 있습니다.  