### PR TITLE
feature: soft delete 

### DIFF
--- a/src/main/java/com/example/repick/domain/product/entity/Payment.java
+++ b/src/main/java/com/example/repick/domain/product/entity/Payment.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -36,8 +37,9 @@ public class Payment extends BaseEntity {
     @Embedded
     private Address address;
 
+    private LocalDateTime deletedAt;
     @Builder
-    public Payment(Long userId, PaymentStatus paymentStatus, String iamportUid, String merchantUid, BigDecimal amount, String userName, String phoneNumber, Address address) {
+    public Payment(Long userId, PaymentStatus paymentStatus, String iamportUid, String merchantUid, BigDecimal amount, String userName, String phoneNumber, Address address, LocalDateTime deletedAt) {
         this.userId = userId;
         this.paymentStatus = paymentStatus;
         this.iamportUid = iamportUid;
@@ -46,6 +48,7 @@ public class Payment extends BaseEntity {
         this.userName = userName;
         this.phoneNumber = phoneNumber;
         this.address = address;
+        this.deletedAt = deletedAt;
     }
 
     public static Payment of(Long userId, String merchantUid, BigDecimal amount, String userName, String phoneNumber, Address address) {
@@ -58,6 +61,13 @@ public class Payment extends BaseEntity {
                 .phoneNumber(phoneNumber)
                 .address(address)
                 .build();
+    }
+    public void setDeletedAt(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
+
+    public void deleteAddress() {
+        this.address = null;
     }
 
     public void updatePaymentStatus(PaymentStatus paymentStatus) {

--- a/src/main/java/com/example/repick/domain/product/repository/PaymentRepository.java
+++ b/src/main/java/com/example/repick/domain/product/repository/PaymentRepository.java
@@ -3,10 +3,16 @@ package com.example.repick.domain.product.repository;
 import com.example.repick.domain.product.entity.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
     Optional<Payment> findByIamportUid(String iamportUid);
 
     Optional<Payment> findByMerchantUid(String merchantUid);
+
+    List<Payment> findAllByUserId(Long userId);
+
+    List<Payment> findAllByDeletedAtBefore(LocalDateTime dateTime);
 }

--- a/src/main/java/com/example/repick/domain/product/scheduler/ProductScheduler.java
+++ b/src/main/java/com/example/repick/domain/product/scheduler/ProductScheduler.java
@@ -100,13 +100,12 @@ public class ProductScheduler {
     @Scheduled(cron = "0 0 0 * * *")
     public void deleteAddressAfterThirtyDays() {
         LocalDateTime thirtyDaysAgo = LocalDateTime.now().minusDays(30);
-        List<Payment> addressToDelete = paymentRepository.findAllByDeletedAtBefore(thirtyDaysAgo);
-
-        addressToDelete.forEach(payment -> {
-            //결제 내역에서 결제 정보만 30일 뒤에 삭제
-            payment.deleteAddress();
-            paymentRepository.save(payment);
-            });
+        paymentRepository.findAllByDeletedAtBefore(thirtyDaysAgo)
+                        .forEach(payment ->  {
+                            //결제 내역에서 결제 정보만 30일 뒤에 삭제
+                            payment.deleteAddress();
+                            paymentRepository.save(payment);
+                        });
     }
 
     // 5년 후 결제 정보 전체 삭제하는 스케줄러

--- a/src/main/java/com/example/repick/domain/user/api/UserController.java
+++ b/src/main/java/com/example/repick/domain/user/api/UserController.java
@@ -14,13 +14,11 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import java.util.Optional;
 
-import java.nio.charset.StandardCharsets;
 
 
 @Tag(name = "User", description = "유저 관련 API")
@@ -226,11 +224,11 @@ public class UserController {
                 
                 """)
     @DeleteMapping("/withdraw")
-    public SuccessResponse<Boolean> withdraw(@Parameter(name = "accessToken", description = "소셜 로그인 인증서버에서 받은 토큰", required = true)
-                                             @RequestParam String accessToken) {
+    public SuccessResponse<Boolean> withdraw(@RequestParam(required = false) Optional<String> accessToken) {
         userService.withdraw(accessToken);
         return SuccessResponse.success(true);
     }
+
 
 
     @Operation(summary = "SMS 인증번호 요청하기",

--- a/src/main/java/com/example/repick/domain/user/api/UserController.java
+++ b/src/main/java/com/example/repick/domain/user/api/UserController.java
@@ -226,8 +226,9 @@ public class UserController {
                 
                 """)
     @DeleteMapping("/withdraw")
-    public SuccessResponse<Boolean> withdraw() {
-        userService.withdraw();
+    public SuccessResponse<Boolean> withdraw(@Parameter(name = "accessToken", description = "소셜 로그인 인증서버에서 받은 토큰", required = true)
+                                             @RequestParam String accessToken) {
+        userService.withdraw(accessToken);
         return SuccessResponse.success(true);
     }
 

--- a/src/main/java/com/example/repick/domain/user/api/UserController.java
+++ b/src/main/java/com/example/repick/domain/user/api/UserController.java
@@ -216,6 +216,22 @@ public class UserController {
         return SuccessResponse.success(userService.deleteUser());
     }
 
+    @Operation(summary = "회원 탈퇴하기",
+            description = """
+                회원 탈퇴 절차를 진행하고, 소셜로그인 연결을 끊습니다.
+                
+                **거래 및 결제 기록과 관련된 정보(이름, 연락처 등)은 5년간 보관합니다.**
+                
+                **그 외의 정보는 30일 후 삭제합니다.**
+                
+                """)
+    @DeleteMapping("/withdraw")
+    public SuccessResponse<Boolean> withdraw() {
+        userService.withdraw();
+        return SuccessResponse.success(true);
+    }
+
+
     @Operation(summary = "SMS 인증번호 요청하기",
             description = """
                     SMS 인증번호를 요청합니다.

--- a/src/main/java/com/example/repick/domain/user/entity/User.java
+++ b/src/main/java/com/example/repick/domain/user/entity/User.java
@@ -8,6 +8,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.joda.time.DateTime;
 
 import java.time.LocalDateTime;
 
@@ -27,7 +28,7 @@ public class User extends BaseEntity {
     private String phoneNumber;
     private String profileImage;
     private String password;
-
+    private LocalDateTime deletedAt;
     // 추가 정보
     private String nickname;
     @Embedded
@@ -56,7 +57,7 @@ public class User extends BaseEntity {
     private Role role;
 
     @Builder
-    public User(Long id, OAuthProvider oAuthProvider, String providerId, String email, String nickname, String phoneNumber, Address defaultAddress, Account defaultAccount, String topSize, String bottomSize, String profileImage, String password, Role role, Boolean pushAllow, String fcmToken, Gender gender ) {
+    public User(Long id, OAuthProvider oAuthProvider, String providerId, String email, String nickname, String phoneNumber, Address defaultAddress, Account defaultAccount, String topSize, String bottomSize, String profileImage, String password, Role role, Boolean pushAllow, String fcmToken, Gender gender,LocalDateTime deletedAt ) {
         this.id = id;
         this.oAuthProvider = oAuthProvider;
         this.providerId = providerId;
@@ -75,6 +76,7 @@ public class User extends BaseEntity {
         this.fcmToken = fcmToken;
         this.userClass = UserClass.ROOKIE_COLLECTOR;
         this.gender = gender;
+        this.deletedAt = deletedAt;
     }
 
 
@@ -88,6 +90,7 @@ public class User extends BaseEntity {
         this.pushAllow = patchUserInfo.pushAllow() != null ? patchUserInfo.pushAllow() : this.pushAllow;
         this.fcmToken = patchUserInfo.fcmToken() != null ? patchUserInfo.fcmToken() : this.fcmToken;
         this.gender = patchUserInfo.gender() != null ? patchUserInfo.gender() : this.gender;
+
     }
 
     public void updateProfile(String profile) {
@@ -102,6 +105,9 @@ public class User extends BaseEntity {
         this.userClass = userClass;
     }
 
+    public void setDeletedAt(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
     public void addSettlement(long settlement) {
         this.settlement += settlement;
     }

--- a/src/main/java/com/example/repick/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/repick/domain/user/repository/UserRepository.java
@@ -2,12 +2,14 @@ package com.example.repick.domain.user.repository;
 
 import com.example.repick.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-
+import java.util.List;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
 
     Optional<User> findByProviderId(String providerId);
+
+    List<User> findAllByDeletedAtBefore(LocalDateTime thirtyDaysAgo);
 
 }

--- a/src/main/java/com/example/repick/domain/user/scheduler/UserScheduler.java
+++ b/src/main/java/com/example/repick/domain/user/scheduler/UserScheduler.java
@@ -1,0 +1,30 @@
+package com.example.repick.domain.user.scheduler;
+
+import com.example.repick.domain.product.entity.Payment;
+import com.example.repick.domain.product.repository.PaymentRepository;
+import com.example.repick.domain.user.entity.User;
+import com.example.repick.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class UserScheduler {
+
+    private final UserRepository userRepository;
+    private final PaymentRepository paymentRepository;
+
+    // 매일 자정에 실행되는 스케줄러
+    @Scheduled(cron = "0 0 0 * * *")
+    public void deleteSoftDeletedUsers() {
+        // 30일이 지난 소프트 삭제된 사용자 조회
+        LocalDateTime thirtyDaysAgo = LocalDateTime.now().minusDays(30);
+        List<User> usersToDelete = userRepository.findAllByDeletedAtBefore(thirtyDaysAgo);
+
+        userRepository.deleteAll(usersToDelete);
+    }
+}

--- a/src/main/java/com/example/repick/domain/user/service/UserService.java
+++ b/src/main/java/com/example/repick/domain/user/service/UserService.java
@@ -67,7 +67,7 @@ public class UserService {
 
     public Boolean patchUserInfo(PatchUserInfo patchUserInfo) {
         User user = userRepository.findByProviderId(SecurityContextHolder.getContext().getAuthentication().getName())
-                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         user.update(patchUserInfo);
 
@@ -83,7 +83,7 @@ public class UserService {
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
 
         User user = userRepository.findByProviderId(email)
-                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         String profile = s3UploadService.saveFile(profileImage, "profile/" + user.getId().toString());
 
@@ -100,7 +100,7 @@ public class UserService {
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
 
         User user = userRepository.findByProviderId(email)
-                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // delete fcm token from ddb
         userFcmTokenInfoRepository.deleteById(user.getId());
@@ -157,7 +157,7 @@ public class UserService {
     @Transactional
     public Boolean initSmsVerification(PostInitSmsVerification postInitSmsVerification) {
         User user = userRepository.findByProviderId(SecurityContextHolder.getContext().getAuthentication().getName())
-                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         String phoneNumber = StringParser.parsePhoneNumber(postInitSmsVerification.phoneNumber());
         String randomNumber = messageService.sendSMS(postInitSmsVerification.phoneNumber());
@@ -177,7 +177,7 @@ public class UserService {
     @Transactional
     public Boolean verifySmsVerification(PostVerifySmsVerification postVerifySmsVerification) {
         User user = userRepository.findByProviderId(SecurityContextHolder.getContext().getAuthentication().getName())
-                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         String phoneNumber = StringParser.parsePhoneNumber(postVerifySmsVerification.phoneNumber());
 

--- a/src/main/java/com/example/repick/domain/user/service/UserService.java
+++ b/src/main/java/com/example/repick/domain/user/service/UserService.java
@@ -31,6 +31,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import java.util.Optional;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -112,7 +113,7 @@ public class UserService {
     }
 
     @Transactional
-    public Boolean withdraw(String accessToken) {
+    public Boolean withdraw(Optional<String> accessToken) {
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
 
         User user = userRepository.findByProviderId(email)
@@ -121,20 +122,19 @@ public class UserService {
         // 소셜 로그인 연결 해제 로직
         switch (user.getOAuthProvider()) {
             case KAKAO:
-                kakaoUserService.disconnectKakao(accessToken);
+                accessToken.ifPresent(kakaoUserService::disconnectKakao);
                 break;
             case NAVER:
-                naverUserService.disconnectNaver(accessToken);
+                accessToken.ifPresent(naverUserService::disconnectNaver);
                 break;
             case GOOGLE:
-                googleUserService.disconnectGoogle(accessToken);
+                accessToken.ifPresent(googleUserService::disconnectGoogle);
                 break;
             case APPLE:
                 break;
             default:
                 throw new CustomException(ErrorCode.INVALID_REQUEST_ERROR);
         }
-
         if (user.getDeletedAt() == null) {
             user.setDeletedAt(LocalDateTime.now());
             user.setIsDeleted();

--- a/src/main/java/com/example/repick/global/entity/BaseEntity.java
+++ b/src/main/java/com/example/repick/global/entity/BaseEntity.java
@@ -27,5 +27,5 @@ public class BaseEntity {
     public void delete() {
         this.isDeleted = true;
     }
-
+    public void setIsDeleted() {this.isDeleted = true;}
 }

--- a/src/main/java/com/example/repick/global/oauth/GoogleUserService.java
+++ b/src/main/java/com/example/repick/global/oauth/GoogleUserService.java
@@ -114,6 +114,12 @@ public class GoogleUserService {
         return Pair.of(googleUser, false);
     }
 
+    public void disconnectGoogle(String accessToken){
+        String url = "https://oauth2.googleapis.com/revoke?token=" + accessToken;
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.postForEntity(url, null, String.class);
+    }
+
     private GoogleUserDto handleGoogleResponse(String responseBody) throws JsonProcessingException {
 
         ObjectMapper objectMapper = new ObjectMapper();

--- a/src/main/java/com/example/repick/global/oauth/KakaoUserService.java
+++ b/src/main/java/com/example/repick/global/oauth/KakaoUserService.java
@@ -50,6 +50,17 @@ public class KakaoUserService {
 
     }
 
+    public void disconnectKakao(String accessToken) {
+        String url = "https://kapi.kakao.com/v1/user/unlink";
+        System.out.println("accessToken: " + accessToken);
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+
+        RestTemplate restTemplate = new RestTemplate();
+        HttpEntity<String> request = new HttpEntity<>(headers);
+        restTemplate.postForEntity(url, request, String.class);
+    }
+
     private KakaoUserDto getKakaoUserInfo(String accessToken) throws JsonProcessingException {
         // HTTP Header 생성
         HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/com/example/repick/global/oauth/NaverUserService.java
+++ b/src/main/java/com/example/repick/global/oauth/NaverUserService.java
@@ -58,6 +58,22 @@ public class NaverUserService {
         return objectMapper.readValue(response.getBody(), NaverUserDto.class);
     }
 
+    public void disconnectNaver(String accessToken) {
+        String url = "https://nid.naver.com/oauth2.0/token?grant_type=delete&client_id=" + clientId +
+                "&client_secret=" + clientSecret + "&access_token=" + accessToken;
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> response = restTemplate.exchange(
+                url,
+                HttpMethod.POST,
+                request,
+                String.class
+        );
+    }
+
+
     private Pair<User, Boolean> registerNaverUserIfNeed(NaverUserDto naverUserInfo) {
         String providerId = naverUserInfo.getId();
         User naverUser = userRepository.findByProviderId(providerId).orElse(null);


### PR DESCRIPTION
개인정보 저장 후 삭제
---

- 기존에 존재하던 Hard Delete 기능 대신, 회원이 탈퇴를 하면 그 시각을 DB에 기록해 놓았다가 개인정보 처리방침에 따라 회원 정보를 영구 삭제해주는 기능을 구현하였습니다. 
- (User 테이블 & Payment 테이블의 address 열은 30일 뒤 삭제, 나머지 Payment 정보는 5년 뒤 삭제) 

![image](https://github.com/user-attachments/assets/2286f950-7375-4513-980b-af0599475071)


소셜로그인 연결 끊기 
---

- 유저의 oAuthProvider를 확인하여 각 소셜로그인의 연결 끊기를 진행해줍니다 (애플은 제외) 
- 애플은 제외 됐기 떄문에 accessToken 입력 부분을 Optional로 변경해주었습니다.