### PR TITLE
fix: bug on like API

### DIFF
--- a/src/main/java/com/example/repick/domain/product/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/example/repick/domain/product/repository/ProductRepositoryCustom.java
@@ -44,8 +44,6 @@ public interface ProductRepositoryCustom {
 
     List<GetProductByClothingSalesDto> findProductDtoByClothingSalesId(long clothingSalesId);
 
-    List<Product> findByProductSellingStateType(ProductStateType productStateType);
-
     List<GetBrandList> getBrandList();
 
     List<Product> findRecommendation(Long userId);


### PR DESCRIPTION
# 좋아요 상품 리스트 API 수정

좋아요 상품 리스트 API에서, 판매중인 상품만 가져오도록 수정하였습니다.

추천 API에서는 문제가 없는것으로 판단되어 수정하지 않았습니다.

# 전반적 상품 조회 로직 리팩토링

상품 조회 시 SELLING 상태를 필터링 하는 로직을 수정하여, join 없이도 처리할 수 있도록 수정했습니다.